### PR TITLE
fix: UIボタンクリック時にカメラモードに入らないように修正

### DIFF
--- a/src/components/viewer/Scene3D.tsx
+++ b/src/components/viewer/Scene3D.tsx
@@ -757,7 +757,19 @@ function FPSCameraControls() {
       }
     };
 
-    const handleClick = () => {
+    const handleClick = (event: MouseEvent) => {
+      // UI要素（ボタンなど）がクリックされた場合はポインターロックをリクエストしない
+      const target = event.target as HTMLElement;
+      if (
+        target.tagName === 'BUTTON' ||
+        target.closest('button') !== null ||
+        target.closest('[role="button"]') !== null ||
+        target.style.zIndex !== '' ||
+        target.closest('[style*="z-index"]') !== null
+      ) {
+        return;
+      }
+
       if (!isPointerLocked) {
         document.body.requestPointerLock();
       }


### PR DESCRIPTION
- FPSCameraControlsのhandleClickで、ボタンやUI要素がクリックされた場合はポインターロックをリクエストしないように変更
- button要素、role='button'要素、z-indexが設定されている要素を除外
- Canvas上をクリックした場合のみポインターロックが有効になる