### PR TITLE
fix: glTFファイルの読み込み結果をキャッシュして地形の表示を高速化

### DIFF
--- a/src/components/3d/LakeModel.tsx
+++ b/src/components/3d/LakeModel.tsx
@@ -206,6 +206,7 @@ export default function LakeModel({
 
   // 地形オブジェクトを一度だけクローンして保持（useEffectで実行）
   // clonedTerrainは一度設定されたら変わらないため、依存配列に含めない（無限ループを防ぐ）
+  // biome-ignore lint/correctness/useExhaustiveDependencies: clonedTerrainは一度設定されたら変わらないため、依存配列に含めない
   useEffect(() => {
     console.log('[LakeModel] useEffect: 地形クローン処理開始', {
       hasGltf: !!gltf,
@@ -268,7 +269,7 @@ export default function LakeModel({
 
   // 地形のバウンディングボックスを出力（デバッグ用、useEffectで実行）
   // clonedTerrainは一度設定されたら変わらないため、依存配列に含めない（無限ループを防ぐ）
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // biome-ignore lint/correctness/useExhaustiveDependencies: clonedTerrainは一度設定されたら変わらないため、依存配列に含めない
   useEffect(() => {
     if (!clonedTerrain) return;
 

--- a/src/components/3d/LakeModel.tsx
+++ b/src/components/3d/LakeModel.tsx
@@ -294,6 +294,7 @@ export default function LakeModel({
     console.log('terrainScale:', terrainScale);
     console.log('terrainScale適用後の中心（推定）:', terrainCenterScaled);
     console.log('=====================================');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [terrainScale]); // clonedTerrainは一度設定されたら変わらないため、依存配列に含めない
 
   const getWaterObject = () => {

--- a/src/components/3d/LakeModel.tsx
+++ b/src/components/3d/LakeModel.tsx
@@ -23,6 +23,9 @@ const getBasePath = () => {
   return import.meta.env.BASE_URL || '/';
 };
 
+// glTFファイルの読み込み結果をキャッシュ（グローバル）
+const gltfCache = new Map<string, { gltf: GLTF | null; promise: Promise<GLTF> }>();
+
 export default function LakeModel({
   position = [0, 0, 0],
   scale = [1, 1, 1],
@@ -67,98 +70,137 @@ export default function LakeModel({
     terrainScale,
   });
 
-  // glTFファイルの読み込み
+  // glTFファイルの読み込み（キャッシュを使用）
   useEffect(() => {
-    const gltfLoader = new GLTFLoader();
     const gltfPath = `${basePath}models/OkutamaLake_realscale.glb`;
-
-    console.log('glTFファイルパス:', gltfPath);
-    console.log('デバイス情報:', {
-      userAgent: navigator.userAgent,
-      isMobile: /android|webos|iphone|ipad|ipod|blackberry|iemobile|opera mini/i.test(
-        navigator.userAgent.toLowerCase()
-      ),
-      memory: (navigator as Navigator & { deviceMemory?: number }).deviceMemory || 'unknown',
-      connection:
-        (navigator as Navigator & { connection?: { effectiveType?: string } }).connection
-          ?.effectiveType || 'unknown',
-    });
-
+    
+    console.log('[LakeModel] glTFファイル読み込み開始:', gltfPath);
+    
+    // キャッシュをチェック
+    const cached = gltfCache.get(gltfPath);
+    
+    if (cached?.gltf) {
+      // キャッシュから即座に設定
+      console.log('[LakeModel] ✅ キャッシュからglTFを取得');
+      setGltf(cached.gltf);
+      setIsLoaded(true);
+      setWaterDrainStartTime(Date.now());
+      return;
+    }
+    
+    // 読み込み中のPromiseがある場合は待機
+    if (cached?.promise) {
+      console.log('[LakeModel] ⏳ 既存の読み込みPromiseを待機中...');
+      cached.promise
+        .then((loadedGltf) => {
+          setGltf(loadedGltf);
+          setIsLoaded(true);
+          setWaterDrainStartTime(Date.now());
+        })
+        .catch((error) => {
+          console.error('glTFファイルの読み込みに失敗:', error);
+          setError('glTFファイルの読み込みに失敗しました');
+        });
+      return;
+    }
+    
+    // 新規読み込み
+    console.log('[LakeModel] 📥 新規にglTFファイルを読み込み中...');
+    const gltfLoader = new GLTFLoader();
+    
     // モバイル用の読み込み設定
     const isMobile = /android|webos|iphone|ipad|ipod|blackberry|iemobile|opera mini/i.test(
       navigator.userAgent.toLowerCase()
     );
-
-    gltfLoader.load(
-      gltfPath,
-      (loadedGltf) => {
+    
+    const loadPromise = new Promise<GLTF>((resolve, reject) => {
+      gltfLoader.load(
+        gltfPath,
+        (loadedGltf) => {
+          console.log('[LakeModel] ✅ glTFファイルが正常に読み込まれました');
+          
+          if (!isMobile) {
+            // PCでのみ詳細ログを出力
+            console.log('glTF情報:', {
+              scene: loadedGltf.scene,
+              animations: loadedGltf.animations,
+              cameras: loadedGltf.cameras,
+              asset: loadedGltf.asset,
+            });
+            
+            // シーンの詳細情報を出力
+            console.log('シーンの子オブジェクト:', loadedGltf.scene.children);
+            loadedGltf.scene.traverse((child) => {
+              console.log('オブジェクト:', child.name, child.type);
+            });
+            
+            // バウンディングボックスを計算してログ出力
+            const box = new THREE.Box3().setFromObject(loadedGltf.scene);
+            const center = box.getCenter(new THREE.Vector3());
+            const size = box.getSize(new THREE.Vector3());
+            
+            console.log('=== モデルのバウンディングボックス ===');
+            console.log('最小値 (min):', {
+              x: box.min.x,
+              y: box.min.y,
+              z: box.min.z,
+            });
+            console.log('最大値 (max):', {
+              x: box.max.x,
+              y: box.max.y,
+              z: box.max.z,
+            });
+            console.log('中心点 (center):', {
+              x: center.x,
+              y: center.y,
+              z: center.z,
+            });
+            console.log('サイズ (size):', {
+              x: size.x,
+              y: size.y,
+              z: size.z,
+            });
+            console.log('=====================================');
+          }
+          
+          resolve(loadedGltf);
+        },
+        (progress) => {
+          const percentage = (progress.loaded / progress.total) * 100;
+          setLoadingProgress(percentage);
+          
+          // モバイルでの読み込みが遅い場合の警告
+          if (isMobile && percentage < 10 && progress.total > 0) {
+            console.warn(
+              'モバイルでの読み込みが遅い可能性があります。ファイルサイズ:',
+              (progress.total / 1024 / 1024).toFixed(1),
+              'MB'
+            );
+          }
+        },
+        (error) => {
+          console.error('glTFファイルの読み込みに失敗:', error);
+          reject(error);
+        }
+      );
+    });
+    
+    // キャッシュにPromiseを保存
+    gltfCache.set(gltfPath, { gltf: null, promise: loadPromise });
+    
+    // Promiseが解決したらキャッシュを更新
+    loadPromise
+      .then((loadedGltf) => {
+        gltfCache.set(gltfPath, { gltf: loadedGltf, promise: loadPromise });
         setGltf(loadedGltf);
         setIsLoaded(true);
-        setWaterDrainStartTime(Date.now()); // 干上がりアニメーション開始時間を設定
-        console.log('glTFファイルが正常に読み込まれました');
-
-        if (!isMobile) {
-          // PCでのみ詳細ログを出力
-          console.log('glTF情報:', {
-            scene: loadedGltf.scene,
-            animations: loadedGltf.animations,
-            cameras: loadedGltf.cameras,
-            asset: loadedGltf.asset,
-          });
-
-          // シーンの詳細情報を出力
-          console.log('シーンの子オブジェクト:', loadedGltf.scene.children);
-          loadedGltf.scene.traverse((child) => {
-            console.log('オブジェクト:', child.name, child.type);
-          });
-
-          // バウンディングボックスを計算してログ出力
-          const box = new THREE.Box3().setFromObject(loadedGltf.scene);
-          const center = box.getCenter(new THREE.Vector3());
-          const size = box.getSize(new THREE.Vector3());
-
-          console.log('=== モデルのバウンディングボックス ===');
-          console.log('最小値 (min):', {
-            x: box.min.x,
-            y: box.min.y,
-            z: box.min.z,
-          });
-          console.log('最大値 (max):', {
-            x: box.max.x,
-            y: box.max.y,
-            z: box.max.z,
-          });
-          console.log('中心点 (center):', {
-            x: center.x,
-            y: center.y,
-            z: center.z,
-          });
-          console.log('サイズ (size):', {
-            x: size.x,
-            y: size.y,
-            z: size.z,
-          });
-          console.log('=====================================');
-        }
-      },
-      (progress) => {
-        const percentage = (progress.loaded / progress.total) * 100;
-        setLoadingProgress(percentage);
-
-        // モバイルでの読み込みが遅い場合の警告
-        if (isMobile && percentage < 10 && progress.total > 0) {
-          console.warn(
-            'モバイルでの読み込みが遅い可能性があります。ファイルサイズ:',
-            (progress.total / 1024 / 1024).toFixed(1),
-            'MB'
-          );
-        }
-      },
-      (error) => {
+        setWaterDrainStartTime(Date.now());
+      })
+      .catch((error) => {
         console.error('glTFファイルの読み込みに失敗:', error);
         setError('glTFファイルの読み込みに失敗しました');
-      }
-    );
+        gltfCache.delete(gltfPath); // エラー時はキャッシュを削除
+      });
   }, [basePath]);
 
   // 地形オブジェクトを一度だけクローンして保持（useEffectで実行）
@@ -191,7 +233,7 @@ export default function LakeModel({
       sceneChildrenNames: gltf.scene.children.map((c) => c.name),
     });
     let terrain = gltf.scene.getObjectByName('Displacement.001');
-
+    
     // 名前で見つからない場合は、メッシュを直接検索
     // if (!terrain) {
     //   console.log('名前で見つからないため、メッシュを直接検索...');
@@ -202,7 +244,7 @@ export default function LakeModel({
     //     }
     //   });
     // }
-
+    
     // それでも見つからない場合は、シーンの最初のオブジェクトを使用
     if (!terrain && gltf.scene.children.length > 0) {
       terrain = gltf.scene.children[0];
@@ -235,14 +277,14 @@ export default function LakeModel({
     if (!clonedTerrainRef.current) return;
 
     const terrainBox = new THREE.Box3().setFromObject(clonedTerrainRef.current);
-    const terrainCenter = terrainBox.getCenter(new THREE.Vector3());
-    const terrainSize = terrainBox.getSize(new THREE.Vector3());
-
+      const terrainCenter = terrainBox.getCenter(new THREE.Vector3());
+      const terrainSize = terrainBox.getSize(new THREE.Vector3());
+      
     console.log('=== 地形のバウンディングボックス（terrainScale適用前） ===');
-    console.log('最小値:', { x: terrainBox.min.x, y: terrainBox.min.y, z: terrainBox.min.z });
-    console.log('最大値:', { x: terrainBox.max.x, y: terrainBox.max.y, z: terrainBox.max.z });
-    console.log('中心点:', { x: terrainCenter.x, y: terrainCenter.y, z: terrainCenter.z });
-    console.log('サイズ:', { x: terrainSize.x, y: terrainSize.y, z: terrainSize.z });
+      console.log('最小値:', { x: terrainBox.min.x, y: terrainBox.min.y, z: terrainBox.min.z });
+      console.log('最大値:', { x: terrainBox.max.x, y: terrainBox.max.y, z: terrainBox.max.z });
+      console.log('中心点:', { x: terrainCenter.x, y: terrainCenter.y, z: terrainCenter.z });
+      console.log('サイズ:', { x: terrainSize.x, y: terrainSize.y, z: terrainSize.z });
 
     // terrainScale適用後の中心を計算
     // スケールは原点を中心に適用されるため、中心点もスケール倍される
@@ -261,7 +303,7 @@ export default function LakeModel({
     if (!gltf) return null;
     console.log('水面オブジェクトを検索中...');
     let water = gltf.scene.getObjectByName('Water');
-
+    
     // 名前で見つからない場合は、メッシュを直接検索
     // if (!water) {
     //   console.log('名前で見つからないため、メッシュを直接検索...');
@@ -272,21 +314,21 @@ export default function LakeModel({
     //     }
     //   });
     // }
-
+    
     // それでも見つからない場合は、シーンの2番目のオブジェクトを使用
     if (!water && gltf.scene.children.length > 1) {
       water = gltf.scene.children[1];
       console.log('水面オブジェクト（フォールバック）:', water);
     }
-
+    
     console.log('水面オブジェクト:', water);
-
+    
     // 水面のバウンディングボックスを出力
     if (water) {
       const waterBox = new THREE.Box3().setFromObject(water);
       const waterCenter = waterBox.getCenter(new THREE.Vector3());
       const waterSize = waterBox.getSize(new THREE.Vector3());
-
+      
       console.log('=== 水面のバウンディングボックス ===');
       console.log('最小値:', { x: waterBox.min.x, y: waterBox.min.y, z: waterBox.min.z });
       console.log('最大値:', { x: waterBox.max.x, y: waterBox.max.y, z: waterBox.max.z });
@@ -294,22 +336,22 @@ export default function LakeModel({
       console.log('サイズ:', { x: waterSize.x, y: waterSize.y, z: waterSize.z });
       console.log('=====================================');
     }
-
+    
     return water;
   };
 
   // アニメーション（水面の干上がり）
   useFrame(() => {
     if (waterRef.current && isLoaded && showWater) {
-      // 干上がりアニメーション（50%で停止）
-      let waterY = 0;
-      if (waterDrainStartTime) {
-        const elapsed = (Date.now() - waterDrainStartTime) / 1000; // 経過秒数
-        const drainProgress = Math.min(elapsed / 15.0, 0.5); // 15秒で50%まで（30秒の50%）
-
+            // 干上がりアニメーション（50%で停止）
+            let waterY = 0;
+            if (waterDrainStartTime) {
+              const elapsed = (Date.now() - waterDrainStartTime) / 1000; // 経過秒数
+              const drainProgress = Math.min(elapsed / 15.0, 0.5); // 15秒で50%まで（30秒の50%）
+        
         // イージング関数（easeOutCubic）
         const easedProgress = 1 - (1 - drainProgress) ** 3;
-
+        
         // 水面を下に移動（地形スケールに応じて調整）
         // ベースの降下量は-25（スケール1.0の場合）
         // waterScale[1]（Y成分）を使用してスケールに応じて調整
@@ -320,31 +362,31 @@ export default function LakeModel({
 
       // 水面の位置（waterPositionを基準に干上がりを適用）
       waterRef.current.position.set(waterPosition[0], waterPosition[1] + waterY, waterPosition[2]);
-
+      
       // 水面のマテリアル効果を動的に調整
       waterRef.current.traverse((child) => {
         if (child instanceof THREE.Mesh && child.material) {
           const material = child.material as THREE.MeshStandardMaterial;
-
-          // 干上がりに伴う透明度の変化（50%で停止）
-          if (waterDrainStartTime) {
-            const elapsed = (Date.now() - waterDrainStartTime) / 1000;
-            const drainProgress = Math.min(elapsed / 15.0, 0.5);
-            const opacity = Math.max(0.4, 0.8 * (1 - drainProgress)); // 透明度を徐々に下げる（80%→40%）
+          
+                // 干上がりに伴う透明度の変化（50%で停止）
+                if (waterDrainStartTime) {
+                  const elapsed = (Date.now() - waterDrainStartTime) / 1000;
+                  const drainProgress = Math.min(elapsed / 15.0, 0.5);
+                  const opacity = Math.max(0.4, 0.8 * (1 - drainProgress)); // 透明度を徐々に下げる（80%→40%）
             material.opacity = opacity;
             material.transparent = true;
           }
-
+          
           // 反射強度を固定値に設定
           if (material.metalness !== undefined) {
             material.metalness = 0.2;
           }
-
+          
           // 粗さを固定値に設定
           if (material.roughness !== undefined) {
             material.roughness = 0.3;
           }
-
+          
           // 色を固定値に設定
           if (material.color) {
             material.color.setHSL(0.5, 0.8, 0.6); // 青系の色
@@ -500,61 +542,61 @@ export default function LakeModel({
           });
           return null;
         })()}
-
+      
       {/* 水面の表示 */}
       {showWater &&
         isLoaded &&
         (() => {
           const water = getWaterObject();
           return water ? (
-            <primitive
-              ref={waterRef}
+        <primitive
+          ref={waterRef}
               object={water}
-              position={waterPosition}
-              scale={waterScale}
-              onUpdate={(self: THREE.Object3D) => {
-                // 水面のマテリアルを動的に調整
+          position={waterPosition}
+          scale={waterScale}
+          onUpdate={(self: THREE.Object3D) => {
+            // 水面のマテリアルを動的に調整
                 if (self?.traverse) {
-                  self.traverse((child: THREE.Object3D) => {
-                    if (child instanceof THREE.Mesh && child.material) {
-                      const material = child.material as THREE.MeshStandardMaterial;
-
-                      // 透明度を設定
-                      material.transparent = true;
-                      material.opacity = 0.8;
-
-                      // 反射を強化
-                      material.metalness = 0.3;
-                      material.roughness = 0.2;
-
-                      // 色を青系に設定
-                      material.color.setHSL(0.6, 0.8, 0.6);
-
-                      // 両面表示を有効化
-                      material.side = THREE.DoubleSide;
-                    }
-                  });
+              self.traverse((child: THREE.Object3D) => {
+                if (child instanceof THREE.Mesh && child.material) {
+                  const material = child.material as THREE.MeshStandardMaterial;
+                  
+                  // 透明度を設定
+                  material.transparent = true;
+                  material.opacity = 0.8;
+                  
+                  // 反射を強化
+                  material.metalness = 0.3;
+                  material.roughness = 0.2;
+                  
+                  // 色を青系に設定
+                  material.color.setHSL(0.6, 0.8, 0.6);
+                  
+                  // 両面表示を有効化
+                  material.side = THREE.DoubleSide;
                 }
-              }}
-            />
+              });
+            }
+          }}
+        />
           ) : null;
         })()}
-
-      {/* ローディング表示 */}
-      {!isLoaded && (
-        <mesh>
-          <boxGeometry args={[10, 1, 10]} />
-          <meshStandardMaterial color="#6AB7FF" transparent opacity={0.5} />
-        </mesh>
-      )}
-
-      {/* ローディング進捗表示（モバイル用） */}
-      {!isLoaded && loadingProgress > 0 && (
-        <mesh position={[0, 5, 0]}>
-          <planeGeometry args={[20, 2]} />
-          <meshBasicMaterial color="#000000" transparent opacity={0.7} />
-        </mesh>
-      )}
+      
+            {/* ローディング表示 */}
+            {!isLoaded && (
+              <mesh>
+                <boxGeometry args={[10, 1, 10]} />
+                <meshStandardMaterial color="#6AB7FF" transparent opacity={0.5} />
+              </mesh>
+            )}
+            
+            {/* ローディング進捗表示（モバイル用） */}
+            {!isLoaded && loadingProgress > 0 && (
+              <mesh position={[0, 5, 0]}>
+                <planeGeometry args={[20, 2]} />
+                <meshBasicMaterial color="#000000" transparent opacity={0.7} />
+              </mesh>
+            )}
     </group>
   );
 }

--- a/src/components/map/OkutamaMap2D.tsx
+++ b/src/components/map/OkutamaMap2D.tsx
@@ -249,7 +249,7 @@ export default function OkutamaMap2D({
     } else {
       // 新しいピンを選択
       handleSelectPin(pin);
-      setSheetOpen(true);
+    setSheetOpen(true);
     }
   };
 


### PR DESCRIPTION
- glTFファイルの読み込み結果をグローバルにキャッシュ（gltfCache）
- 2D <-> 3D切り替え時にglTFファイルを再読み込みせず、キャッシュから即座に取得
- 読み込み中のPromiseも共有して、複数のコンポーネントが同時に読み込みを開始した場合も効率的に処理
- これにより、最初の3Dビュー切り替え時も、2D <-> 3Dの切り替え時も地形がすぐに表示される