### PR TITLE
fix: 2D↔3D切り替え後に水面アニメーションが開始されない問題を修正

### DIFF
--- a/src/components/3d/LakeModel.tsx
+++ b/src/components/3d/LakeModel.tsx
@@ -315,12 +315,20 @@ export default function LakeModel({
       const cloned = water.clone();
       clonedWaterRef.current = cloned; // refにも保持（後方互換性のため）
       setClonedWater(cloned); // Reactの状態として設定
+      
+      // アニメーション開始時間を設定（まだ設定されていない場合のみ）
+      if (waterDrainStartTime === null) {
+        setWaterDrainStartTime(Date.now());
+        console.log('[LakeModel] ✅ アニメーション開始時間を設定しました');
+      }
+      
       console.log('[LakeModel] ✅ 水面オブジェクトをクローンしました:', {
         clonedObject: cloned,
         name: cloned.name,
         type: cloned.type,
         uuid: cloned.uuid,
         renderCount: renderCountRef.current,
+        waterDrainStartTime: waterDrainStartTime || Date.now(),
       });
     } else {
       console.warn('[LakeModel] ❌ 水面オブジェクトが見つかりませんでした', {


### PR DESCRIPTION
- clonedWaterが設定された時点でwaterDrainStartTimeがnullの場合は、アニメーション開始時間を設定するように修正
- これにより、2D↔3Dの切り替え後でもアニメーションが確実に開始されるように改善