### PR TITLE
fix: ドロワーを閉じてもピンの選択状態を保持するように修正

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -121,7 +121,12 @@ function App() {
   if (appState === '3d-view') {
     return (
       <div>
-        <Scene3D initialPosition={initial3DPosition} selectedPin={selectedPin} />
+        <Scene3D 
+          initialPosition={initial3DPosition} 
+          selectedPin={selectedPin}
+          onSelectPin={setSelectedPin}
+          onDeselectPin={() => setSelectedPin(null)}
+        />
         {/* 2Dに戻る（右上・円形アイコンボタン） */}
         <div
           style={{

--- a/src/components/ui/PinListDrawer.tsx
+++ b/src/components/ui/PinListDrawer.tsx
@@ -49,7 +49,7 @@ export default function PinListDrawer({
   const handleOpenChange = (isOpen: boolean) => {
     onOpenChange(isOpen);
     if (!isOpen) {
-      onDeselectPin();
+      // ドロワーを閉じても選択状態は保持する（onDeselectPinを呼ばない）
       setSheetMode('pin-list');
     }
   };

--- a/src/components/viewer/Scene3D.tsx
+++ b/src/components/viewer/Scene3D.tsx
@@ -29,6 +29,8 @@ import {
 interface Scene3DProps {
   initialPosition?: Initial3DPosition | null;
   selectedPin?: PinData | null;
+  onSelectPin?: (pin: PinData) => void;
+  onDeselectPin?: () => void;
 }
 
 // 地形の位置補正値を計算（スケール適用後の中心を原点に配置するため）
@@ -48,11 +50,18 @@ const calculateTerrainPosition = (): [number, number, number] => {
 };
 
 // 3Dシーンコンポーネント
-export default function Scene3D({ initialPosition, selectedPin: propSelectedPin }: Scene3DProps) {
+export default function Scene3D({ 
+  initialPosition, 
+  selectedPin: propSelectedPin,
+  onSelectPin: propOnSelectPin,
+  onDeselectPin: propOnDeselectPin,
+}: Scene3DProps) {
   const { isDevMode } = useDevModeStore();
   const [sheetOpen, setSheetOpen] = useState<boolean>(false);
   const [localSelectedPin, setLocalSelectedPin] = useState<PinData | null>(null);
   const selectedPin = propSelectedPin ?? localSelectedPin;
+  const handleSelectPin = propOnSelectPin ?? setLocalSelectedPin;
+  const handleDeselectPin = propOnDeselectPin ?? (() => setLocalSelectedPin(null));
   const [webglSupport, setWebglSupport] = useState<WebGLSupport | null>(null);
   const [renderer, setRenderer] = useState<string>('webgl2');
   const [permissionGranted, setPermissionGranted] = useState(() => {
@@ -327,8 +336,8 @@ export default function Scene3D({ initialPosition, selectedPin: propSelectedPin 
         open={sheetOpen}
         onOpenChange={setSheetOpen}
         selectedPin={selectedPin}
-        onSelectPin={setLocalSelectedPin}
-        onDeselectPin={() => setLocalSelectedPin(null)}
+        onSelectPin={handleSelectPin}
+        onDeselectPin={handleDeselectPin}
       />
 
       {/* デバイス向き許可ボタン（モバイルのみ） */}


### PR DESCRIPTION
- PinListDrawerのhandleOpenChangeで、ドロワーを閉じたときにonDeselectPin()を呼ばないように変更
- Scene3DにonSelectPinとonDeselectPinのpropsを追加
- App.tsxで選択状態を管理し、Scene3Dにpropsとして渡す
- これにより、2Dビューと3Dビュー間で選択状態が共有され、ドロワーを閉じても選択が保持されるように改善