### PR TITLE
fix: ドロワーを開いても水面の位置がリセットされないように修正（シーンに直接追加）

### DIFF
--- a/src/components/3d/LakeModel.tsx
+++ b/src/components/3d/LakeModel.tsx
@@ -390,7 +390,6 @@ export default function LakeModel({
         console.log('[LakeModel] ✅ 水面をシーンから削除しました（クリーンアップ）');
       }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [clonedWater, showWater, isLoaded, waterScale, scene]);
 
   // 地形のバウンディングボックスを出力（デバッグ用、useEffectで実行）


### PR DESCRIPTION
- primitiveコンポーネントを使わず、useEffectでシーンに直接clonedWaterオブジェクトを追加
- これにより、primitiveコンポーネントの再マウントによる位置リセットを回避
- useThreeフックを使用してシーンへの参照を取得
- waterGroupRefを使用して水面用のGroupを管理
- useFrame内でclonedWaterオブジェクトとwaterGroupRefの位置を同期
- クリーンアップ関数でシーンから削除する処理を追加