### PR TITLE
feat: wireframe toggle for 3D view

### DIFF
--- a/src/components/3d/LakeModel.tsx
+++ b/src/components/3d/LakeModel.tsx
@@ -16,6 +16,7 @@ interface LakeModelProps {
   terrainScale?: [number, number, number];
   waterScale?: [number, number, number];
   waterPosition?: [number, number, number];
+  wireframe?: boolean;
 }
 
 // ベースパスを動的に取得
@@ -43,6 +44,7 @@ export default function LakeModel({
   terrainScale = [1, 1, 1],
   waterScale = [1, 1, 1],
   waterPosition = [0, 0, 0],
+  wireframe = false,
 }: LakeModelProps) {
   const terrainRef = useRef<THREE.Group>(null);
   const waterRef = useRef<THREE.Group>(null);
@@ -558,10 +560,10 @@ export default function LakeModel({
           },
           waterRefPosition: waterRef.current?.position
             ? {
-                x: waterRef.current.position.x.toFixed(2),
-                y: waterRef.current.position.y.toFixed(2),
-                z: waterRef.current.position.z.toFixed(2),
-              }
+              x: waterRef.current.position.x.toFixed(2),
+              y: waterRef.current.position.y.toFixed(2),
+              z: waterRef.current.position.z.toFixed(2),
+            }
             : null,
           globalWaterDrainStartTime: globalWaterDrainStartTime.value,
         });
@@ -613,6 +615,29 @@ export default function LakeModel({
       });
     }
   });
+
+  // ワイヤーフレーム表示の切り替えを反映
+  useEffect(() => {
+    const applyWireframe = (obj: THREE.Object3D | null) => {
+      if (!obj) return;
+      obj.traverse((child) => {
+        if (child instanceof THREE.Mesh && child.material) {
+          if (Array.isArray(child.material)) {
+            for (const mat of child.material) {
+              if ('wireframe' in mat) {
+                (mat as any).wireframe = wireframe;
+              }
+            }
+          } else if ('wireframe' in child.material) {
+            (child.material as any).wireframe = wireframe;
+          }
+        }
+      });
+    };
+
+    applyWireframe(clonedTerrain);
+    applyWireframe(clonedWater);
+  }, [wireframe, clonedTerrain, clonedWater]);
 
   // 地形モデルと水面の実際の位置を確認するためのデバッグログ
   // 注意: useEffectは早期リターンの前に配置する必要がある（React Hooksのルール）
@@ -725,10 +750,10 @@ export default function LakeModel({
     hasClonedTerrain: !!clonedTerrain,
     terrainObject: clonedTerrain
       ? {
-          name: clonedTerrain.name,
-          type: clonedTerrain.type,
-          uuid: clonedTerrain.uuid,
-        }
+        name: clonedTerrain.name,
+        type: clonedTerrain.type,
+        uuid: clonedTerrain.uuid,
+      }
       : null,
     renderCount: renderCountRef.current,
   });

--- a/src/components/viewer/Scene3D.tsx
+++ b/src/components/viewer/Scene3D.tsx
@@ -81,6 +81,7 @@ export default function Scene3D({
   const [fov, setFov] = useState(DEFAULT_FOV);
   const [showDebug, setShowDebug] = useState(false);
   const [isArBackgroundActive, setIsArBackgroundActive] = useState(true);
+  const [isWireframe, setIsWireframe] = useState(false);
 
   useEffect(() => {
     detectWebGLSupport().then((support) => {
@@ -246,6 +247,7 @@ export default function Scene3D({
             visible={true}
             showTerrain={true} // 地形を表示
             showWater={true} // 水面を表示
+            wireframe={isWireframe}
             terrainScale={[
               TERRAIN_BASE_SCALE * TERRAIN_SCALE_FACTOR,
               TERRAIN_BASE_SCALE * TERRAIN_SCALE_FACTOR,
@@ -503,8 +505,8 @@ export default function Scene3D({
             />
           </div>
 
-          {/* AR背景トグル */}
-          <div style={{ width: '100%', display: 'flex', justifyContent: 'center' }}>
+          {/* AR背景トグル & ワイヤーフレーム */}
+          <div style={{ width: '100%', display: 'flex', justifyContent: 'center', gap: '10px' }}>
             <button
               type="button"
               onClick={() => setIsArBackgroundActive(!isArBackgroundActive)}
@@ -517,9 +519,29 @@ export default function Scene3D({
                 borderRadius: '15px',
                 cursor: 'pointer',
                 transition: 'all 0.2s',
+                flex: 1,
+                maxWidth: '120px',
               }}
             >
               AR背景: {isArBackgroundActive ? 'ON' : 'OFF'}
+            </button>
+            <button
+              type="button"
+              onClick={() => setIsWireframe(!isWireframe)}
+              style={{
+                background: isWireframe ? '#2B6CB0' : 'rgba(255,255,255,0.2)',
+                border: 'none',
+                color: 'white',
+                fontSize: '11px',
+                padding: '6px 12px',
+                borderRadius: '15px',
+                cursor: 'pointer',
+                transition: 'all 0.2s',
+                flex: 1,
+                maxWidth: '120px',
+              }}
+            >
+              線画: {isWireframe ? 'ON' : 'OFF'}
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
This PR adds a wireframe toggle to the 3D AR view.

### Enhancements
- **Wireframe Mode**: Users can now toggle wireframe (mesh) display for the terrain and water. This is useful for observing the underlying 3D structure and for precise alignment with the AR background.
- **UI Integration**: Added a '線画' (Wireframe) button next to the AR background toggle in the control panel.
- **LakeModel Update**: Added a dynamic material update logic to support wireframe switching without re-mounting.

Co-Authored-By: gemini-cli <218195315+gemini-cli@users.noreply.github.com>