### PR TITLE
fix: set default terrain height on raycast timeout

### DIFF
--- a/src/components/viewer/Scene3D.tsx
+++ b/src/components/viewer/Scene3D.tsx
@@ -927,6 +927,12 @@ function CameraPositionSetter({
     if (frameCount.current >= maxFrames) {
       camera.position.set(cameraX, finalCameraY, cameraZ);
       hasSetPosition.current = true;
+
+      // タイムアウト時も基準高さを設定して、その後の調整を可能にする
+      // finalCameraY = terrainHeight + CAMERA_HEIGHT_OFFSET + heightOffset なので
+      // terrainHeight = finalCameraY - CAMERA_HEIGHT_OFFSET - heightOffset
+      baseTerrainHeightRef.current = finalCameraY - CAMERA_HEIGHT_OFFSET - heightOffset;
+
       console.warn('=== カメラ高さ調整（タイムアウト） ===');
       console.warn('地形との交差が見つかりませんでした。デフォルトの高さを使用します。');
       console.warn('見つかったMesh:', foundMeshes);


### PR DESCRIPTION
## 修正内容
*   地形検出タイムアウト時にデフォルトの基準高さを設定するように変更
*   地形読み込み失敗時でもカメラ高度調整スライダーが機能するように修正

## 検証
*   実機確認: タイムアウトログが出力された後でもスライダーで高さが変わることを確認