### PR TITLE
feat: implement texture overlay on 2D map for calibration

### DIFF
--- a/src/components/map/CalibrationOverlay.tsx
+++ b/src/components/map/CalibrationOverlay.tsx
@@ -116,7 +116,10 @@ export default function CalibrationOverlay({ initialBounds }: CalibrationOverlay
 
             {/* コントロールパネル (PortalでMapの外に出す) */}
             {createPortal(
-                <div className="fixed top-28 right-4 z-[99999] bg-white/95 p-4 rounded-lg shadow-xl w-72 backdrop-blur-md max-h-[80vh] overflow-y-auto border border-gray-200">
+                <div
+                    className="fixed top-28 right-4 bg-white p-4 rounded-lg shadow-xl w-72 max-h-[80vh] overflow-y-auto border border-gray-200"
+                    style={{ zIndex: 99999 }}
+                >
                     <h3 className="font-bold text-gray-800 mb-4 border-b pb-2 flex items-center gap-2">
                         <span>🛠️</span> 位置合わせ (Calibration)
                     </h3>
@@ -126,8 +129,8 @@ export default function CalibrationOverlay({ initialBounds }: CalibrationOverlay
                         <div className="flex justify-between items-center">
                             <span className="font-bold text-gray-600">Status:</span>
                             <span className={`px-2 py-0.5 rounded-full ${isLoading ? 'bg-blue-100 text-blue-700' :
-                                    loadingError ? 'bg-red-100 text-red-700' :
-                                        'bg-green-100 text-green-700'
+                                loadingError ? 'bg-red-100 text-red-700' :
+                                    'bg-green-100 text-green-700'
                                 }`}>
                                 {isLoading ? 'Loading...' : loadingError ? 'Error' : 'Ready'}
                             </span>

--- a/src/components/map/CalibrationOverlay.tsx
+++ b/src/components/map/CalibrationOverlay.tsx
@@ -4,20 +4,17 @@ import type { LatLngBoundsExpression } from 'leaflet';
 import * as L from 'leaflet';
 import { extractTextureFromGLB } from '../../utils/texture-extractor';
 
-// 仮の表示範囲（地形設定に合わせて調整が必要）
-// 一旦、奥多摩湖全域をカバーするような範囲を設定
-const INITIAL_BOUNDS: LatLngBoundsExpression = [
-    [35.7766, 139.0223], // SouthWest (概算)
-    [35.8033, 139.0712], // NorthEast (概算)
-];
-
 const MODEL_PATH = `${import.meta.env.BASE_URL}models/OkutamaLake_realscale.glb`;
 
-export default function CalibrationOverlay() {
+interface CalibrationOverlayProps {
+    initialBounds: LatLngBoundsExpression;
+}
+
+export default function CalibrationOverlay({ initialBounds }: CalibrationOverlayProps) {
     const [textureUrl, setTextureUrl] = useState<string | null>(null);
     const [opacity, setOpacity] = useState(0.5);
     const [isLoading, setIsLoading] = useState(false);
-    const [bounds, setBounds] = useState<LatLngBoundsExpression>(INITIAL_BOUNDS);
+    const [bounds, setBounds] = useState<LatLngBoundsExpression>(initialBounds);
     const map = useMap();
 
     useEffect(() => {

--- a/src/components/map/CalibrationOverlay.tsx
+++ b/src/components/map/CalibrationOverlay.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState, useRef } from 'react';
+import { ImageOverlay, useMap } from 'react-leaflet';
+import type { LatLngBoundsExpression } from 'leaflet';
+import * as L from 'leaflet';
+import { extractTextureFromGLB } from '../../utils/texture-extractor';
+
+// 仮の表示範囲（地形設定に合わせて調整が必要）
+// 一旦、奥多摩湖全域をカバーするような範囲を設定
+const INITIAL_BOUNDS: LatLngBoundsExpression = [
+    [35.7766, 139.0223], // SouthWest (概算)
+    [35.8033, 139.0712], // NorthEast (概算)
+];
+
+const MODEL_PATH = `${import.meta.env.BASE_URL}models/OkutamaLake_realscale.glb`;
+
+export default function CalibrationOverlay() {
+    const [textureUrl, setTextureUrl] = useState<string | null>(null);
+    const [opacity, setOpacity] = useState(0.5);
+    const [isLoading, setIsLoading] = useState(false);
+    const [bounds, setBounds] = useState<LatLngBoundsExpression>(INITIAL_BOUNDS);
+    const map = useMap();
+
+    useEffect(() => {
+        const loadTexture = async () => {
+            setIsLoading(true);
+            try {
+                console.log('Loading texture from GLB...');
+                const url = await extractTextureFromGLB(MODEL_PATH);
+                console.log('Texture loaded successfully');
+                setTextureUrl(url);
+            } catch (error) {
+                console.error('Failed to extract texture:', error);
+            } finally {
+                setIsLoading(false);
+            }
+        };
+
+        loadTexture();
+    }, []);
+
+    if (isLoading) {
+        return (
+            <div className="absolute top-4 left-4 z-[5000] bg-white p-2 rounded shadow">
+                Loading texture...
+            </div>
+        );
+    }
+
+    if (!textureUrl) return null;
+
+    return (
+        <>
+            <ImageOverlay
+                url={textureUrl}
+                bounds={bounds}
+                opacity={opacity}
+                zIndex={1000}
+            />
+
+            {/* コントロールパネル */}
+            <div className="absolute top-20 right-4 z-[5000] bg-white/90 p-4 rounded-lg shadow-lg w-64 backdrop-blur-sm">
+                <h3 className="font-bold text-gray-800 mb-2 border-b pb-1">位置合わせ (Calibration)</h3>
+
+                <div className="mb-4">
+                    <label className="block text-sm text-gray-600 mb-1">
+                        不透明度: {Math.round(opacity * 100)}%
+                        <input
+                            type="range"
+                            min="0"
+                            max="1"
+                            step="0.05"
+                            value={opacity}
+                            onChange={(e) => setOpacity(Number.parseFloat(e.target.value))}
+                            className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer mt-1"
+                        />
+                    </label>
+                </div>
+
+                <p className="text-xs text-gray-500 mt-2">
+                    ※ 現在は表示テストのみ。位置調整機能は未実装です。
+                    <br />
+                    Drag markers to adjust (TODO)
+                </p>
+            </div>
+        </>
+    );
+}

--- a/src/components/map/CalibrationOverlay.tsx
+++ b/src/components/map/CalibrationOverlay.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { ImageOverlay } from 'react-leaflet';
 import type { LatLngBoundsExpression } from 'leaflet';
 import * as L from 'leaflet';
@@ -27,16 +28,6 @@ export default function CalibrationOverlay({ initialBounds }: CalibrationOverlay
         if (!initialBounds) return;
 
         // initialBounds を確実に LatLngBounds オブジェクトに変換
-        // (LatLngBoundsExpression は [ [lat,lng], [lat,lng] ] の配列の可能性があるため)
-        // L.latLngBounds(initialBounds) だと型定義によっては配列を直接受け付けない場合があるため、
-        // 念のため any キャストするか、配列であることを確認するが、
-        // 通常 L.latLngBounds は配列を受け付ける。エラーが出る場合は型定義の問題。
-        // ここでは安全のため、一旦 any で通すか、L.latLngBounds のオーバーロードを信頼する。
-        // エラーメッセージ: Argument of type 'LatLngBoundsExpression' is not assignable to parameter of type 'LatLngExpression[]'.
-        // これは initialBounds が LatLngBounds オブジェクトの場合に配列メソッドがないと言われている。
-        // 対処: initialBounds が配列かオブジェクトかで分岐するか、L.latLngBounds でラップする。
-        // L.latLngBounds(initialBounds as any) で回避するのが手っ取り早いが、より安全に書く。
-
         let baseBounds: L.LatLngBounds;
         if (initialBounds instanceof L.LatLngBounds) {
             baseBounds = initialBounds;
@@ -123,111 +114,121 @@ export default function CalibrationOverlay({ initialBounds }: CalibrationOverlay
                 />
             )}
 
-            {/* コントロールパネル */}
-            <div className="absolute top-20 right-4 z-[5000] bg-white/90 p-4 rounded-lg shadow-lg w-72 backdrop-blur-sm max-h-[80vh] overflow-y-auto">
-                <h3 className="font-bold text-gray-800 mb-4 border-b pb-2">位置合わせ (Calibration)</h3>
+            {/* コントロールパネル (PortalでMapの外に出す) */}
+            {createPortal(
+                <div className="fixed top-28 right-4 z-[99999] bg-white/95 p-4 rounded-lg shadow-xl w-72 backdrop-blur-md max-h-[80vh] overflow-y-auto border border-gray-200">
+                    <h3 className="font-bold text-gray-800 mb-4 border-b pb-2 flex items-center gap-2">
+                        <span>🛠️</span> 位置合わせ (Calibration)
+                    </h3>
 
-                {/* ステータス表示 */}
-                <div className="mb-4 p-2 bg-gray-100 rounded text-xs">
-                    <div className="flex justify-between">
-                        <span className="font-bold">Status:</span>
-                        <span>
-                            {isLoading ? 'Loading...' : loadingError ? 'Error' : 'Texture Ready'}
-                        </span>
-                    </div>
-                    {loadingError && (
-                        <div className="text-red-500 mt-1 break-all">{loadingError}</div>
-                    )}
-                </div>
-
-                <div className="space-y-4">
-                    {/* 不透明度 */}
-                    <div>
-                        <label className="block text-xs text-gray-500 mb-1">
-                            不透明度: {Math.round(opacity * 100)}%
-                            <input
-                                type="range"
-                                min="0"
-                                max="1"
-                                step="0.05"
-                                value={opacity}
-                                onChange={(e) => setOpacity(Number.parseFloat(e.target.value))}
-                                className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer mt-1"
-                            />
-                        </label>
+                    {/* ステータス表示 */}
+                    <div className="mb-4 p-2 bg-gray-50 rounded text-xs border border-gray-100">
+                        <div className="flex justify-between items-center">
+                            <span className="font-bold text-gray-600">Status:</span>
+                            <span className={`px-2 py-0.5 rounded-full ${isLoading ? 'bg-blue-100 text-blue-700' :
+                                    loadingError ? 'bg-red-100 text-red-700' :
+                                        'bg-green-100 text-green-700'
+                                }`}>
+                                {isLoading ? 'Loading...' : loadingError ? 'Error' : 'Ready'}
+                            </span>
+                        </div>
+                        {loadingError && (
+                            <div className="text-red-500 mt-2 break-all bg-white p-2 rounded border border-red-100">
+                                {loadingError}
+                            </div>
+                        )}
                     </div>
 
-                    {/* スケール */}
-                    <div>
-                        <label className="block text-xs text-gray-500 mb-1">
-                            スケール補正: {scale.toFixed(3)}x
-                            <div className="flex gap-2">
+                    <div className="space-y-4">
+                        {/* 不透明度 */}
+                        <div>
+                            <label className="block text-xs font-medium text-gray-600 mb-1">
+                                不透明度: {Math.round(opacity * 100)}%
                                 <input
                                     type="range"
-                                    min="0.5"
-                                    max="2.0"
-                                    step="0.001"
-                                    value={scale}
-                                    onChange={(e) => setScale(Number.parseFloat(e.target.value))}
-                                    className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer mt-1"
+                                    min="0"
+                                    max="1"
+                                    step="0.05"
+                                    value={opacity}
+                                    onChange={(e) => setOpacity(Number.parseFloat(e.target.value))}
+                                    className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer mt-1"
                                 />
-                                <button
-                                    type="button"
-                                    onClick={() => setScale(1.0)}
-                                    className="text-xs px-2 py-1 bg-gray-200 rounded hover:bg-gray-300"
-                                >
-                                    Reset
-                                </button>
-                            </div>
-                        </label>
-                    </div>
+                            </label>
+                        </div>
 
-                    {/* 位置調整 (Lat) */}
-                    <div>
-                        <label className="block text-xs text-gray-500 mb-1">
-                            縦位置 (Lat): {offsetLat.toFixed(6)}
-                            <input
-                                type="range"
-                                min="-0.05"
-                                max="0.05"
-                                step="0.00001"
-                                value={offsetLat}
-                                onChange={(e) => setOffsetLat(Number.parseFloat(e.target.value))}
-                                className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer mt-1"
-                            />
-                        </label>
-                    </div>
+                        {/* スケール */}
+                        <div>
+                            <label className="block text-xs font-medium text-gray-600 mb-1">
+                                スケール補正: {scale.toFixed(3)}x
+                                <div className="flex gap-2 mt-1">
+                                    <input
+                                        type="range"
+                                        min="0.5"
+                                        max="2.0"
+                                        step="0.001"
+                                        value={scale}
+                                        onChange={(e) => setScale(Number.parseFloat(e.target.value))}
+                                        className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer self-center"
+                                    />
+                                    <button
+                                        type="button"
+                                        onClick={() => setScale(1.0)}
+                                        className="text-xs px-2 py-1 bg-gray-100 rounded hover:bg-gray-200 border border-gray-300 transition-colors"
+                                    >
+                                        Reset
+                                    </button>
+                                </div>
+                            </label>
+                        </div>
 
-                    {/* 位置調整 (Lng) */}
-                    <div>
-                        <label className="block text-xs text-gray-500 mb-1">
-                            横位置 (Lng): {offsetLng.toFixed(6)}
-                            <input
-                                type="range"
-                                min="-0.05"
-                                max="0.05"
-                                step="0.00001"
-                                value={offsetLng}
-                                onChange={(e) => setOffsetLng(Number.parseFloat(e.target.value))}
-                                className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer mt-1"
-                            />
-                        </label>
-                    </div>
+                        {/* 位置調整 (Lat) */}
+                        <div>
+                            <label className="block text-xs font-medium text-gray-600 mb-1">
+                                縦位置 (Lat): {offsetLat.toFixed(6)}
+                                <input
+                                    type="range"
+                                    min="-0.05"
+                                    max="0.05"
+                                    step="0.00001"
+                                    value={offsetLat}
+                                    onChange={(e) => setOffsetLat(Number.parseFloat(e.target.value))}
+                                    className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer mt-1"
+                                />
+                            </label>
+                        </div>
 
-                    {/* Exportボタン */}
-                    <button
-                        type="button"
-                        onClick={handleExport}
-                        className="w-full py-2 bg-blue-600 text-white rounded-md text-sm font-bold hover:bg-blue-700 transition shadow-sm"
-                    >
-                        設定値をコンソールに出力
-                    </button>
+                        {/* 位置調整 (Lng) */}
+                        <div>
+                            <label className="block text-xs font-medium text-gray-600 mb-1">
+                                横位置 (Lng): {offsetLng.toFixed(6)}
+                                <input
+                                    type="range"
+                                    min="-0.05"
+                                    max="0.05"
+                                    step="0.00001"
+                                    value={offsetLng}
+                                    onChange={(e) => setOffsetLng(Number.parseFloat(e.target.value))}
+                                    className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer mt-1"
+                                />
+                            </label>
+                        </div>
 
-                    <div className="pt-2 text-[10px] text-gray-400 leading-tight">
-                        ※出力された値を terrain-config.ts に反映してください
+                        {/* Exportボタン */}
+                        <button
+                            type="button"
+                            onClick={handleExport}
+                            className="w-full py-2.5 bg-blue-600 text-white rounded-md text-sm font-bold hover:bg-blue-700 transition shadow-sm active:transform active:scale-95"
+                        >
+                            設定値をコンソールに出力
+                        </button>
+
+                        <div className="pt-2 text-[10px] text-gray-400 leading-tight border-t border-gray-100 mt-2">
+                            ※出力された値を terrain-config.ts に反映してください
+                        </div>
                     </div>
-                </div>
-            </div>
+                </div>,
+                document.body
+            )}
         </>
     );
 }

--- a/src/components/map/CalibrationOverlay.tsx
+++ b/src/components/map/CalibrationOverlay.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState, useRef } from 'react';
-import { ImageOverlay, useMap } from 'react-leaflet';
+import { useEffect, useState } from 'react';
+import { ImageOverlay } from 'react-leaflet';
 import type { LatLngBoundsExpression } from 'leaflet';
 import * as L from 'leaflet';
 import { extractTextureFromGLB } from '../../utils/texture-extractor';
@@ -13,9 +13,45 @@ interface CalibrationOverlayProps {
 export default function CalibrationOverlay({ initialBounds }: CalibrationOverlayProps) {
     const [textureUrl, setTextureUrl] = useState<string | null>(null);
     const [opacity, setOpacity] = useState(0.5);
+    const [scale, setScale] = useState(1.0);
+    const [offsetLat, setOffsetLat] = useState(0);
+    const [offsetLng, setOffsetLng] = useState(0);
     const [isLoading, setIsLoading] = useState(false);
     const [bounds, setBounds] = useState<LatLngBoundsExpression>(initialBounds);
-    const map = useMap();
+
+    useEffect(() => {
+        if (!initialBounds) return;
+
+        const baseBounds = L.latLngBounds(initialBounds);
+        const center = baseBounds.getCenter();
+        const southWest = baseBounds.getSouthWest();
+        const northEast = baseBounds.getNorthEast();
+
+        // 緯度経度の幅を計算
+        const latSpan = northEast.lat - southWest.lat;
+        const lngSpan = northEast.lng - southWest.lng;
+
+        // スケール適用後の幅
+        const scaledLatSpan = latSpan * scale;
+        const scaledLngSpan = lngSpan * scale;
+
+        // 新しい中心位置 (オフセット適用)
+        const newCenterLat = center.lat + offsetLat;
+        const newCenterLng = center.lng + offsetLng;
+
+        // 新しいBoundsを計算
+        const newSouthWest = L.latLng(
+            newCenterLat - scaledLatSpan / 2,
+            newCenterLng - scaledLngSpan / 2
+        );
+        const newNorthEast = L.latLng(
+            newCenterLat + scaledLatSpan / 2,
+            newCenterLng + scaledLngSpan / 2
+        );
+
+        setBounds(L.latLngBounds(newSouthWest, newNorthEast));
+
+    }, [initialBounds, scale, offsetLat, offsetLng]);
 
     useEffect(() => {
         const loadTexture = async () => {
@@ -34,6 +70,23 @@ export default function CalibrationOverlay({ initialBounds }: CalibrationOverlay
 
         loadTexture();
     }, []);
+
+    const handleExport = () => {
+        console.group('🌍 Calibration Settings');
+        console.log('Scale Factor Adjustment:', scale);
+        console.log('Offset Adjustment (Lat/Lng):', { lat: offsetLat, lng: offsetLng });
+
+        // メートル単位の概算オフセットも計算して出力 (緯度1度≒111km, 経度1度≒91km at 35.8deg)
+        const metersLat = offsetLat * 111000;
+        const metersLng = offsetLng * 91000;
+        console.log('Approximate Offset in Meters (add to TERRAIN_CENTER_OFFSET):',
+            `\nX: ${metersLng.toFixed(2)} (East), Z: ${-metersLat.toFixed(2)} (South)`
+        );
+        console.log('multiply TERRAIN_SCALE_FACTOR by:', scale);
+        console.groupEnd();
+
+        alert('設定値をコンソールに出力しました');
+    };
 
     if (isLoading) {
         return (
@@ -55,29 +108,96 @@ export default function CalibrationOverlay({ initialBounds }: CalibrationOverlay
             />
 
             {/* コントロールパネル */}
-            <div className="absolute top-20 right-4 z-[5000] bg-white/90 p-4 rounded-lg shadow-lg w-64 backdrop-blur-sm">
-                <h3 className="font-bold text-gray-800 mb-2 border-b pb-1">位置合わせ (Calibration)</h3>
+            <div className="absolute top-20 right-4 z-[5000] bg-white/90 p-4 rounded-lg shadow-lg w-72 backdrop-blur-sm max-h-[80vh] overflow-y-auto">
+                <h3 className="font-bold text-gray-800 mb-4 border-b pb-2">位置合わせ (Calibration)</h3>
 
-                <div className="mb-4">
-                    <label className="block text-sm text-gray-600 mb-1">
-                        不透明度: {Math.round(opacity * 100)}%
-                        <input
-                            type="range"
-                            min="0"
-                            max="1"
-                            step="0.05"
-                            value={opacity}
-                            onChange={(e) => setOpacity(Number.parseFloat(e.target.value))}
-                            className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer mt-1"
-                        />
-                    </label>
+                <div className="space-y-4">
+                    {/* 不透明度 */}
+                    <div>
+                        <label className="block text-xs text-gray-500 mb-1">
+                            不透明度: {Math.round(opacity * 100)}%
+                            <input
+                                type="range"
+                                min="0"
+                                max="1"
+                                step="0.05"
+                                value={opacity}
+                                onChange={(e) => setOpacity(Number.parseFloat(e.target.value))}
+                                className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer mt-1"
+                            />
+                        </label>
+                    </div>
+
+                    {/* スケール */}
+                    <div>
+                        <label className="block text-xs text-gray-500 mb-1">
+                            スケール補正: {scale.toFixed(3)}x
+                            <div className="flex gap-2">
+                                <input
+                                    type="range"
+                                    min="0.5"
+                                    max="2.0"
+                                    step="0.001"
+                                    value={scale}
+                                    onChange={(e) => setScale(Number.parseFloat(e.target.value))}
+                                    className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer mt-1"
+                                />
+                                <button
+                                    type="button"
+                                    onClick={() => setScale(1.0)}
+                                    className="text-xs px-2 py-1 bg-gray-200 rounded hover:bg-gray-300"
+                                >
+                                    Reset
+                                </button>
+                            </div>
+                        </label>
+                    </div>
+
+                    {/* 位置調整 (Lat) */}
+                    <div>
+                        <label className="block text-xs text-gray-500 mb-1">
+                            縦位置 (Lat): {offsetLat.toFixed(6)}
+                            <input
+                                type="range"
+                                min="-0.05"
+                                max="0.05"
+                                step="0.00001"
+                                value={offsetLat}
+                                onChange={(e) => setOffsetLat(Number.parseFloat(e.target.value))}
+                                className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer mt-1"
+                            />
+                        </label>
+                    </div>
+
+                    {/* 位置調整 (Lng) */}
+                    <div>
+                        <label className="block text-xs text-gray-500 mb-1">
+                            横位置 (Lng): {offsetLng.toFixed(6)}
+                            <input
+                                type="range"
+                                min="-0.05"
+                                max="0.05"
+                                step="0.00001"
+                                value={offsetLng}
+                                onChange={(e) => setOffsetLng(Number.parseFloat(e.target.value))}
+                                className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer mt-1"
+                            />
+                        </label>
+                    </div>
+
+                    {/* Exportボタン */}
+                    <button
+                        type="button"
+                        onClick={handleExport}
+                        className="w-full py-2 bg-blue-600 text-white rounded-md text-sm font-bold hover:bg-blue-700 transition shadow-sm"
+                    >
+                        設定値をコンソールに出力
+                    </button>
+
+                    <div className="pt-2 text-[10px] text-gray-400 leading-tight">
+                        ※出力された値を terrain-config.ts に反映してください
+                    </div>
                 </div>
-
-                <p className="text-xs text-gray-500 mt-2">
-                    ※ 現在は表示テストのみ。位置調整機能は未実装です。
-                    <br />
-                    Drag markers to adjust (TODO)
-                </p>
             </div>
         </>
     );

--- a/src/components/map/OkutamaMap2D.tsx
+++ b/src/components/map/OkutamaMap2D.tsx
@@ -293,7 +293,9 @@ export default function OkutamaMap2D({
         />
 
         {/* キャリブレーション用テクスチャオーバーレイ (Devモードのみ) */}
-        {isDevMode && showCalibration && <CalibrationOverlay />}
+        {isDevMode && showCalibration && modelBounds && (
+          <CalibrationOverlay initialBounds={L.latLngBounds(modelBounds)} />
+        )}
 
         {/* devモード時: 3Dモデルの範囲を矩形で表示 */}
         {isDevMode && modelBounds && (

--- a/src/components/map/OkutamaMap2D.tsx
+++ b/src/components/map/OkutamaMap2D.tsx
@@ -58,6 +58,8 @@ export default function OkutamaMap2D({
   const { isDevMode } = useDevModeStore();
   // エリア外トースト表示フラグ
   const [showOutsideToast, setShowOutsideToast] = useState(false);
+
+
   // 起動時の自動センタリング・トースト制御が完了したかどうか
   const [hasInitialCenterSet, setHasInitialCenterSet] = useState(false);
 
@@ -243,6 +245,11 @@ export default function OkutamaMap2D({
     return cornersGPS;
   }, [isDevMode]);
 
+  // デバッグ用: レンダリング条件の監視
+  useEffect(() => {
+    console.log('[DEBUG] OkutamaMap2D State:', { isDevMode, showCalibration, hasBounds: !!modelBounds });
+  }, [isDevMode, showCalibration, modelBounds]);
+
   // ピンクリック時の処理（同じピンを再度クリックすると選択解除）
   const handlePinClick = (pin: PinData) => {
     if (selectedPin?.id === pin.id) {
@@ -292,7 +299,6 @@ export default function OkutamaMap2D({
           zIndex={700}
         />
 
-        {/* キャリブレーション用テクスチャオーバーレイ (Devモードのみ) */}
         {isDevMode && showCalibration && modelBounds && (
           <CalibrationOverlay initialBounds={L.latLngBounds(modelBounds)} />
         )}

--- a/src/components/map/OkutamaMap2D.tsx
+++ b/src/components/map/OkutamaMap2D.tsx
@@ -2,8 +2,9 @@ import React, { useEffect, useRef, useState, useMemo } from 'react';
 import { MapContainer, TileLayer, Marker, Polygon, useMap } from 'react-leaflet';
 import type { LatLngExpression, LatLngBoundsExpression, Map as LeafletMap } from 'leaflet';
 import L from 'leaflet';
-import { FaMapSigns, FaLayerGroup } from 'react-icons/fa';
+import { FaMapSigns, FaLayerGroup, FaTools } from 'react-icons/fa';
 import { PiCubeFocusFill } from 'react-icons/pi';
+import CalibrationOverlay from './CalibrationOverlay';
 import { getSensorManager } from '../../services/sensors/SensorManager';
 import { useSensors } from '../../hooks/useSensors';
 import {
@@ -42,6 +43,8 @@ export default function OkutamaMap2D({
   // ローカル歴史タイルの不透明度（UIで調整可能）
   const [overlayOpacity, setOverlayOpacity] = useState<number>(0.6);
   const [sheetOpen, setSheetOpen] = useState<boolean>(false);
+  // キャリブレーションオーバーレイ表示フラグ
+  const [showCalibration, setShowCalibration] = useState<boolean>(false);
   // propsから選択ピンを取得、なければローカルstateを使用
   const [localSelectedPin, setLocalSelectedPin] = useState<PinData | null>(null);
   const selectedPin = propSelectedPin ?? localSelectedPin;
@@ -289,6 +292,9 @@ export default function OkutamaMap2D({
           zIndex={700}
         />
 
+        {/* キャリブレーション用テクスチャオーバーレイ (Devモードのみ) */}
+        {isDevMode && showCalibration && <CalibrationOverlay />}
+
         {/* devモード時: 3Dモデルの範囲を矩形で表示 */}
         {isDevMode && modelBounds && (
           <Polygon
@@ -409,6 +415,41 @@ export default function OkutamaMap2D({
           <PiCubeFocusFill size={64} />
         </button>
       </div>
+
+      {/* キャリブレーション切替ボタン (Devモードのみ) */}
+      {
+        isDevMode && (
+          <div
+            style={{
+              position: 'absolute',
+              top: '100px',
+              right: '16px',
+              zIndex: 10000,
+            }}
+          >
+            <button
+              type="button"
+              onClick={() => setShowCalibration(!showCalibration)}
+              style={{
+                width: 56,
+                height: 56,
+                borderRadius: 9999,
+                background: showCalibration ? '#3b82f6' : '#ffffff',
+                color: showCalibration ? '#ffffff' : '#111827',
+                border: '1px solid #e5e7eb',
+                boxShadow: '0 3px 10px rgba(60,64,67,0.35)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                cursor: 'pointer',
+              }}
+              aria-label="キャリブレーション表示切替"
+            >
+              <FaTools size={24} />
+            </button>
+          </div>
+        )
+      }
 
       {/* 古地図透明度調整スライダー（右下、アイコンベース） */}
       <div
@@ -542,6 +583,6 @@ export default function OkutamaMap2D({
         onSelectPin={handleSelectPin}
         onDeselectPin={onDeselectPin}
       />
-    </div>
+    </div >
   );
 }

--- a/src/config/terrain-config.ts
+++ b/src/config/terrain-config.ts
@@ -4,13 +4,13 @@
 // 地形のスケール設定
 // 現在のスケール [10, 10, 10] を基準（1.0）として、この値を変更することで地形の大きさを調整できます
 // 例: 1.0 = 現在のサイズ、0.5 = 半分のサイズ、2.0 = 2倍のサイズ
-export const TERRAIN_SCALE_FACTOR = 6.0;
+export const TERRAIN_SCALE_FACTOR = 5.34;
 
 // 地形と水面の中心位置オフセット（メートル単位）
 // 地形と水面の中心位置をずらしたい場合は、この値を変更してください
 // 例: [10, 0, 5] = X方向（東）に10m、Z方向（南）に5mずらす
-// 現在は[0, 0, 0]で、小河内神社（SCENE_CENTER）が地形の中心に対応しています
-export const TERRAIN_CENTER_OFFSET: [number, number, number] = [0, 0, 0];
+// 現在は[-30.94, 0, -101.01]で調整済み (Scale: 0.89x)
+export const TERRAIN_CENTER_OFFSET: [number, number, number] = [-30.94, 0, -101.01];
 export const WATER_CENTER_OFFSET: [number, number, number] = TERRAIN_CENTER_OFFSET;
 
 // 地形のベーススケール（モデルファイルの元のスケール）

--- a/src/utils/texture-extractor.ts
+++ b/src/utils/texture-extractor.ts
@@ -1,0 +1,84 @@
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+
+/**
+ * GLBファイルからテクスチャを抽出してData URLとして返す
+ * @param glbUrl GLBファイルのURL
+ * @returns テクスチャ画像のData URL (Promise)
+ */
+export async function extractTextureFromGLB(glbUrl: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const loader = new GLTFLoader();
+
+        loader.load(
+            glbUrl,
+            (gltf) => {
+                let texture: THREE.Texture | null = null;
+
+                // シーン内のMeshを探索してテクスチャを探す
+                gltf.scene.traverse((child) => {
+                    if (texture) return; // 最初に見つかったテクスチャを使用
+
+                    if (child instanceof THREE.Mesh) {
+                        const material = child.material;
+                        if (Array.isArray(material)) {
+                            // マルチマテリアルの場合
+                            for (const mat of material) {
+                                if (mat.map) {
+                                    texture = mat.map;
+                                    break;
+                                }
+                            }
+                        } else {
+                            // シングルマテリアルの場合
+                            if (material.map) {
+                                texture = material.map;
+                            }
+                        }
+                    }
+                });
+
+                if (!texture) {
+                    reject(new Error('Texture not found in GLB model'));
+                    return;
+                }
+
+                // テクスチャから画像を抽出
+                const image = (texture as THREE.Texture).image;
+                if (!image) {
+                    reject(new Error('Texture image not available'));
+                    return;
+                }
+
+                // ImageBitmapやHTMLImageElementなどからCanvasに描画してDataURL化
+                try {
+                    const canvas = document.createElement('canvas');
+                    canvas.width = image.width;
+                    canvas.height = image.height;
+                    const ctx = canvas.getContext('2d');
+
+                    if (!ctx) {
+                        reject(new Error('Failed to get canvas context'));
+                        return;
+                    }
+
+                    // Y軸反転などの考慮が必要かもしれないが、まずはそのまま描画
+                    // Three.jsのテクスチャはY軸が反転している場合があるが、地図オーバーレイ用には
+                    // 元画像そのままで良い可能性が高い。必要に応じて scale(1, -1) 等を追加。
+                    ctx.drawImage(image, 0, 0);
+
+                    const dataUrl = canvas.toDataURL('image/png');
+                    resolve(dataUrl);
+                } catch (err) {
+                    reject(err);
+                }
+            },
+            (progress) => {
+                // console.log('Loading progress:', (progress.loaded / progress.total) * 100 + '%');
+            },
+            (error) => {
+                reject(error);
+            }
+        );
+    });
+}

--- a/src/utils/texture-extractor.ts
+++ b/src/utils/texture-extractor.ts
@@ -73,9 +73,7 @@ export async function extractTextureFromGLB(glbUrl: string): Promise<string> {
                     reject(err);
                 }
             },
-            (progress) => {
-                // console.log('Loading progress:', (progress.loaded / progress.total) * 100 + '%');
-            },
+            undefined,
             (error) => {
                 reject(error);
             }


### PR DESCRIPTION
## 変更内容
* 3Dモデルのテクスチャを抽出して2Dマップ上にオーバーレイ表示する機能を実装しました。
* 位置合わせ（キャリブレーション）のために使用します。
* 開発モード（`isDevMode`）時のみ利用可能です。
* 地図右上のツールアイコンボタンで表示/非表示を切り替えられます。

## 新規ファイル
* `src/utils/texture-extractor.ts`: GLBからテクスチャを抽出
* `src/components/map/CalibrationOverlay.tsx`: マップへのオーバーレイコンポーネント