### PR TITLE
feat: update launch position and pin visibility

### DIFF
--- a/src/components/viewer/Scene3D.tsx
+++ b/src/components/viewer/Scene3D.tsx
@@ -1253,9 +1253,9 @@ function PinMarker({
       // 3D空間上の位置を基準に距離を計算
       const pinPosition = new THREE.Vector3(basePosition[0], pinHeight, basePosition[2]);
       // 二乗距離で判定（1m = 1m^2）
-      // ユーザー要望により 100m (100 * 100) 以内は非表示に変更
+      // ユーザー要望により 200m (200 * 200) 以内は非表示に変更
       const distSq = camera.position.distanceToSquared(pinPosition);
-      groupRef.current.visible = distSq >= 10000;
+      groupRef.current.visible = distSq >= 40000;
     }
   });
 


### PR DESCRIPTION
## 概要
- GPS範囲外時の初期表示位置を「奥多摩湖の碑」に変更しました。
- ARビューでのピン非表示距離を 200m に調整しました。
- デバッグ用のピンデータを追加・更新しました。
- Lintエラーを修正しました。

## 詳細
- `src/utils/coordinate-converter.ts`: `OGOUCHI_SHRINE` を `DEFAULT_START_POSITION` に変更し、座標更新。
- `src/components/viewer/Scene3D.tsx`: ピン非表示距離の閾値を変更。
- `src/utils/texture-extractor.ts`: 未使用変数の削除。

## 確認事項
- [x] エリア外の場合、マップ初期位置が奥多摩湖の碑になること
- [x] ピン表示制御の距離確認