### PR TITLE
feat: adjust AR specs and initial position

### DIFF
--- a/src/components/map/OkutamaMap2D.tsx
+++ b/src/components/map/OkutamaMap2D.tsx
@@ -8,7 +8,7 @@ import CalibrationOverlay from './CalibrationOverlay';
 import { getSensorManager } from '../../services/sensors/SensorManager';
 import { useSensors } from '../../hooks/useSensors';
 import {
-  OGOUCHI_SHRINE,
+  DEFAULT_START_POSITION,
   worldToGpsCoordinate,
   SCENE_CENTER,
 } from '../../utils/coordinate-converter';
@@ -184,10 +184,10 @@ export default function OkutamaMap2D({
       // エリア内なのでトーストは非表示
       setShowOutsideToast(false);
     } else {
-      // エリア外の場合：小河内神社を中心に設定
-      const shrineCenter: LatLngExpression = [OGOUCHI_SHRINE.latitude, OGOUCHI_SHRINE.longitude];
-      setCenter(shrineCenter);
-      mapRef.current?.flyTo(shrineCenter, 14, { duration: 0.6 });
+      // エリア外の場合：初期位置（奥多摩湖の碑）を中心に設定
+      const startCenter: LatLngExpression = [DEFAULT_START_POSITION.latitude, DEFAULT_START_POSITION.longitude];
+      setCenter(startCenter);
+      mapRef.current?.flyTo(startCenter, 14, { duration: 0.6 });
       // エリア外トーストを表示
       setShowOutsideToast(true);
     }

--- a/src/components/map/OkutamaMap2D.tsx
+++ b/src/components/map/OkutamaMap2D.tsx
@@ -63,10 +63,10 @@ export default function OkutamaMap2D({
   // 起動時の自動センタリング・トースト制御が完了したかどうか
   const [hasInitialCenterSet, setHasInitialCenterSet] = useState(false);
 
-  // 画面中心位置（初期値は小河内神社）
+  // 画面中心位置（初期値は奥多摩湖の碑）
   const [center, setCenter] = useState<LatLngExpression>([
-    OGOUCHI_SHRINE.latitude,
-    OGOUCHI_SHRINE.longitude,
+    DEFAULT_START_POSITION.latitude,
+    DEFAULT_START_POSITION.longitude,
   ]);
   const MapRefBinder = () => {
     const map = useMap();

--- a/src/utils/coordinate-converter.ts
+++ b/src/utils/coordinate-converter.ts
@@ -24,10 +24,10 @@ export const SCENE_CENTER: GPSCoordinate = {
 // 小河内ダム周辺の基準座標（奥多摩湖）- 後方互換性のため保持
 export const OKUTAMA_DAM_CENTER: GPSCoordinate = SCENE_CENTER;
 
-// 小河内神社の座標（エリア外の場合の初期表示位置）
-export const OGOUCHI_SHRINE: GPSCoordinate = {
-  latitude: 35.777041,
-  longitude: 139.0185245,
+// 奥多摩湖の碑（エリア外の場合の初期表示位置）
+export const DEFAULT_START_POSITION: GPSCoordinate = {
+  latitude: 35.792151,
+  longitude: 139.048165,
   altitude: 0, // 標高は後で調整可能
 };
 


### PR DESCRIPTION
## 概要
- GPS範囲外時の初期表示位置を「奥多摩湖の碑」に変更しました。
- ARビューでのピン非表示距離を 200m に調整しました。
- デバッグ用のピンデータを追加・更新しました。
- Lintエラーを修正しました。

## 詳細
- `src/utils/coordinate-converter.ts`: `OGOUCHI_SHRINE` を `DEFAULT_START_POSITION` に変更し、座標更新。
- `src/components/viewer/Scene3D.tsx`: ピン非表示距離の閾値を変更。
- `src/utils/texture-extractor.ts`: 未使用変数の削除。

## 確認事項
- [x] エリア外の場合、マップ初期位置が奥多摩湖の碑になること
- [x] ピン表示制御の距離確認