### PR TITLE
fix: GLTFモデル読み込みエラーの修正

### DIFF
--- a/docs/fix_camera_freeze/task.md
+++ b/docs/fix_camera_freeze/task.md
@@ -12,6 +12,7 @@
 - [x] 手動検証 (ドキュメント作成)
     - [x] `walkthrough.md` の作成 (日本語)
 - [x] プルリクエストの作成 [PR #123](https://github.com/hirosukedayo/kotei-lens/pull/123)
+- [x] デバッグ用PRの作成 [PR #124](https://github.com/hirosukedayo/kotei-lens/pull/124)
 
 ## 次のステップ
 - [ ] ユーザーによる手動検証
@@ -19,7 +20,8 @@
     - [x] 1秒ごとのGPSログが大量に出る問題を報告
 - [ ] トラブルシューティング: 地形消失とログの調査
     - [x] `LocationService.ts` の過剰なログを削除
-    - [ ] `LakeModel.tsx` のレンダリング条件を確認 (デバッグログ追加済み)
+    - [x] `LakeModel.tsx` のレンダリング条件を確認 (デバッグログ追加済み)
+    - [x] `LakeModel.tsx` のGLTFパスのTypo修正 (`models /` -> `models/`)
     - [ ] 修正と検証
     - [ ] `Scene3D.tsx` の `CameraPositionSetter` との整合性確認
     - [ ] 修正と検証

--- a/src/components/3d/LakeModel.tsx
+++ b/src/components/3d/LakeModel.tsx
@@ -99,7 +99,7 @@ export function LakeModel({
 
   // glTFファイルの読み込み（キャッシュを使用）
   useEffect(() => {
-    const gltfPath = `${basePath} models / OkutamaLake_realscale.glb`;
+    const gltfPath = `${basePath}models/OkutamaLake_realscale.glb`;
 
     console.log('[LakeModel] glTFファイル読み込み開始:', gltfPath);
 


### PR DESCRIPTION
## 概要
地形モデル読み込み時に `SyntaxError: Unexpected token <` が発生してモデルが表示されない問題を修正しました。

## 原因
`LakeModel.tsx` 内のGLTFファイルパスを構築する文字列に不要なスペース（` models / `）が含まれており、正しいURL（`models/...`）として認識されず404エラー（index.htmlの返却）が発生していました。

## 修正内容
パスの文字列結合を修正し、正しいパスが生成されるようにしました。