### PR TITLE
fix: ensure calibration on first load and refine orientation logic

### DIFF
--- a/src/components/viewer/Scene3D.tsx
+++ b/src/components/viewer/Scene3D.tsx
@@ -313,6 +313,7 @@ export default function Scene3D({
               deviceOrientation={sensorData.orientation}
               arMode={true}
               manualHeadingOffset={manualHeadingOffset}
+              baseHeadingOffset={initialPosition?.headingOffset ?? 0}
             />
           )}
           {/* FPSスタイルカメラコントロール（PCのみ） */}


### PR DESCRIPTION
## 概要
PR #129 のマージ後に判明した、初回ロード時のキャリブレーションスキップと、方位の安定性向上に対する追加修正です。

## 修正内容
1.  **初回ロード時のキャリブレーション強制**
    *   `OkutamaMap2D.tsx`: これまでは「許可済み」だとキャリブレーションをスキップするロジックが含まれていましたが、モバイル端末の場合は初回でも必ずキャリブレーション（水平・方位調整）画面を経由するように修正しました。

2.  **相対方位によるカメラ制御 (安定化)**
    *   **課題**: iOSの電子コンパス (`webkitCompassHeading`) は、端末を立てた状態（AR利用時）で不安定になりやすい。
    *   **解決策**:
        *   キャリブレーション完了（端末が水平）のタイミングで、「コンパス方位」と「ジャイロセンサーの方位 (Alpha)」の差分（`headingOffset`）を計算・保存します。
        *   3D/ARモード中は、この初期オフセットに、ジャイロセンサーの相対変化 (`alpha`) を加算することでカメラを制御します。
        *   `OrientationCamera.tsx`: 不安定な `webkitCompassHeading` を直接使用するロジックを廃止し、`baseHeadingOffset` (初期オフセット) + `alpha` で計算する方式に一本化しました。

## 確認事項
- 初めてアプリを開いたときでも、3Dボタンを押すとキャリブレーション画面が表示されること。
- キャリブレーション後に3D画面に移った際、地形の方位がおおよそ合っていること。
- 端末を左右に振った際、カクつきが軽減されていること（ジャイロベースのため）。