### PR TITLE
fix: ローディング画面のZ-index修正

### DIFF
--- a/src/components/ui/LoadingScreen.tsx
+++ b/src/components/ui/LoadingScreen.tsx
@@ -34,7 +34,7 @@ export default function LoadingScreen({ isReady = false }: LoadingScreenProps) {
                         alignItems: 'center',
                         justifyContent: 'center',
                         background: 'rgba(0, 0, 0, 1.0)', // 完全不透明にして裏のフリーズを隠す
-                        zIndex: 9999,
+                        zIndex: 100000,
                         color: 'white',
                     }}
                 >


### PR DESCRIPTION
## 修正内容
1.  **ローディング画面のオーバーレイ優先度修正**:
    -  の z-index を `9999` から `100000` に変更しました。
    - これにより、ピンリストボタン（z-index: 10000）やその他のUI要素がロード画面の手前に表示されてしまう問題を解消しました。