### PR TITLE
UI改善・修正一括対応

### DIFF
--- a/src/components/ui/CompassCalibration.tsx
+++ b/src/components/ui/CompassCalibration.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { FaCheck, FaHandPointer, FaTimes, FaUndo, FaArrowLeft } from 'react-icons/fa';
+import { FaCheck, FaHandPointer, FaUndo, FaArrowLeft } from 'react-icons/fa';
+import { IoCloseOutline } from 'react-icons/io5';
 import type { DeviceOrientation } from '../../types/sensors';
 
 interface CompassCalibrationProps {
@@ -261,7 +262,7 @@ export default function CompassCalibration({
                                     cursor: 'pointer',
                                 }}
                             >
-                                <FaTimes size={24} />
+                                <IoCloseOutline size={30} />
                             </button>
                         </div>
                     )}


### PR DESCRIPTION
## 概要
以下の修正を一括して反映します。

### 1. 3DビューのUI整理
- 左上のボタンを「設定・調整」（目のアイコン）一つに集約
- デバッグ情報ボタンを設定パネル内に移動
- ピンリストボタンを常時表示に変更

### 2. ローディング画面の修正
- LoadingScreenのZ-indexを修正し、オーバーレイ問題を解消

### 3. コンパス調整画面のデザイン修正
- 「戻る」「閉じる」ボタンを56pxの円形ボタンスタイル（半透明）に統一
- 閉じるボタンのアイコンを細身の `IoCloseOutline` に変更