### PR TITLE
feat: 地図タイルを高解像度XYZ形式に更新

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ vite.config.ts.timestamp-*
 # SSL Certificates
 .cert/
 .DS_Store
+
+# Large Map Tiles
+public/tiles/

--- a/src/components/map/OkutamaMap2D.tsx
+++ b/src/components/map/OkutamaMap2D.tsx
@@ -242,7 +242,7 @@ export default function OkutamaMap2D({
   }, [sensorData.gps, sensorManager.locationService, hasInitialCenterSet]);
   // public配下のタイルは Vite の base に追従して配信される
   const tilesBase = import.meta.env.BASE_URL || '/';
-  const localTilesUrl = `${tilesBase}tiles_okutama/{z}/{x}/{y}.png`;
+  const localTilesUrl = `${tilesBase}tiles/{z}/{x}/{y}.png`;
 
   // 固定の表示範囲（緯度経度）。
   // 体験エリア + 小河内神社 + その周辺を十分に含むよう、以前よりかなり広めに設定
@@ -339,7 +339,7 @@ export default function OkutamaMap2D({
         <TileLayer
           url={localTilesUrl}
           noWrap
-          tms
+          /* tms */
           minZoom={12}
           maxZoom={20}
           opacity={overlayOpacity}

--- a/src/components/map/OkutamaMap2D.tsx
+++ b/src/components/map/OkutamaMap2D.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState, useMemo } from 'react';
-import { MapContainer, TileLayer, Marker, Polygon, useMap } from 'react-leaflet';
+import { MapContainer, TileLayer, Marker, Polygon, useMap, useMapEvents } from 'react-leaflet';
 import type { LatLngExpression, LatLngBoundsExpression, Map as LeafletMap } from 'leaflet';
 import L from 'leaflet';
 import { FaMapSigns, FaLayerGroup, FaTools, FaLocationArrow } from 'react-icons/fa';
@@ -79,6 +79,16 @@ export default function OkutamaMap2D({
       if (mapRef.current) return;
       mapRef.current = map;
     }, [map]);
+    return null;
+  };
+
+  // デバッグ用: クリックした座標をコンソールに表示
+  const MapClickLogger = () => {
+    useMapEvents({
+      click(e) {
+        console.log(`Clicked Coordinate: [${e.latlng.lat}, ${e.latlng.lng}]`);
+      },
+    });
     return null;
   };
 
@@ -331,6 +341,7 @@ export default function OkutamaMap2D({
       >
         <MapRefBinder />
         {/* ベース: OSM */}
+        <MapClickLogger />
         <TileLayer
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'

--- a/src/types/pins.ts
+++ b/src/types/pins.ts
@@ -61,6 +61,11 @@ export const pinTypeStyles: Record<
     icon: '🍜',
     label: '飲食店',
   },
+  interview: {
+    color: '#3B82F6',
+    icon: '🗣️',
+    label: 'インタビュー',
+  },
   debug: {
     color: '#000',
     icon: '👨‍💻',


### PR DESCRIPTION
## 概要\nQGIS/gdal2tilesで新たに生成した高解像度タイルを使用するように変更しました。\n\n## 変更点\n- タイル参照先を `tiles_okutama` から `tiles` に変更\n- 座標系を TMS から XYZ (標準的) に変更するため、`tms` プロパティを無効化\n- 生成されたタイル群 (`public/tiles/`) を `.gitignore` に追加 (リポジトリ肥大化防止)\n\n## 検証\nローカル環境で詳細レベル(z=20)まで地図が表示されることを確認。