### PR TITLE
feat: 方位許可（2Dモード）とキャリブレーション改善

### DIFF
--- a/docs/heading_permission_and_marker/implementation_plan.md
+++ b/docs/heading_permission_and_marker/implementation_plan.md
@@ -1,0 +1,78 @@
+# 方位取得許可の2Dモード起動時取得 & ユーザーアイコンのGoogle Maps風変更
+
+## 背景
+
+現状、方位（DeviceOrientation）の許可は3Dモードへの遷移時に初めて取得される。そのため、2Dモードでユーザー位置マーカーの向きが反映されない。
+また、ユーザー位置のアイコンは矢印型SVGだが、Google Maps風のドット+視野円弧に変更する。
+
+## 要件
+
+1. **方位許可を2Dモード起動時に取得する** — アプリ起動直後に方位許可のリクエストを行い、許可が得られれば方位をリアルタイムで反映
+2. **ユーザー位置アイコンをGoogle Maps風に変更** — 中心に青い丸（ドット）、視野方向にグラデーションの扇形（円弧）が広がるスタイル
+3. **方位許可が取れなかった場合** — 円弧を非表示にし、青い丸のみ表示
+
+## 変更方針
+
+### 問題の根本原因
+
+`useSensors.ts`の`startSensors()`は、2Dモード起動時に`autoRequest=false`で呼ばれる（L105）。
+`OrientationService.startTracking()`は`autoRequestPermission=false`の場合、未許可なら方位のトラッキングをスキップする（L65-71）。
+
+iOSでは`DeviceOrientationEvent.requestPermission()`がユーザーインタラクション（ボタンクリック等）内での呼び出しを要求するため、自動でリクエストはできない。
+
+---
+
+### コンポーネント1: 方位許可の2Dモード起動時取得
+
+#### [MODIFY] [OkutamaMap2D.tsx](file:///Users/hirosuke/ghq/github.com/hirosukedayo/kotei-lens/src/components/map/OkutamaMap2D.tsx)
+
+- 2Dモード表示時に、方位許可が未取得の場合、許可取得用のバナー（ボタン）を画面上部に表示
+- ユーザーがタップすると`OrientationService.requestPermission()`を呼び出し、許可が得られたら`startSensors(true, true)`でセンサーを再起動
+- 許可状態を追跡する`headingPermission`ステートを追加
+- 許可が得られたか否かを`CurrentLocationMarker`に`hasHeading`プロパティで伝達
+
+**実装詳細:**
+- 初回マウント時に`sensorManager.orientationService.getPermissionState()`をチェック
+- `unknown`または`prompt`の場合、画面上部に「🧭 方位を有効にする」ボタンを表示
+- ボタンクリック時（ユーザーインタラクション内なのでiOSでも動作）:
+  1. `sensorManager.orientationService.requestPermission()` を呼び出し
+  2. 許可が得られたら `startSensors(true, true)` でセンサー再起動
+  3. `headingPermission` を `'granted'` に更新
+- 許可が拒否された場合はバナーを非表示にし、`headingPermission` を `'denied'` に設定
+
+---
+
+### コンポーネント2: ユーザー位置アイコンのGoogle Maps風変更
+
+#### [MODIFY] [OkutamaMap2D.tsx](file:///Users/hirosuke/ghq/github.com/hirosukedayo/kotei-lens/src/components/map/OkutamaMap2D.tsx)
+
+`CurrentLocationMarker`コンポーネントのSVGを以下に変更:
+
+- **中心の青い丸**: `#4285F4`（Google Blue）、白い縁取り付き
+- **視野の扇形**: 中心から前方に広がるグラデーション扇形（視野角約70度）
+  - 中心部は不透明度が高く、外側に向かって透明になる
+  - デバイスの方位に応じて全体を回転
+- **方位データがない場合**: 円弧を非表示にし、青い丸のみ表示
+
+**propsの変更:**
+- `hasHeading: boolean` を追加し、方位許可状態に応じて円弧の表示/非表示を切り替え
+
+---
+
+## 検証計画
+
+### ビルド検証
+
+```bash
+pnpm run lint
+pnpm run build
+```
+
+### 手動検証
+
+ユーザーに実機での確認を依頼:
+- 2Dモード起動時に方位許可バナーが表示される
+- 許可タップ後、iOSダイアログが表示される
+- 許可取得後、円弧付きマーカーが方位に追従する
+- 許可拒否後、青い丸のみ表示される
+- 3Dモードへの遷移が正常動作する

--- a/docs/heading_permission_and_marker/task.md
+++ b/docs/heading_permission_and_marker/task.md
@@ -1,0 +1,11 @@
+# タスクリスト: 方位許可 & マーカースタイル変更
+
+- [x] ブランチ作成 (`feat/heading-permission-and-marker-style`)
+- [x] `OkutamaMap2D.tsx` の変更
+  - [x] `headingPermission` ステート追加
+  - [x] 方位許可取得バナーUI実装
+  - [x] `CurrentLocationMarker` をGoogle Maps風に変更
+  - [x] 方位なし時は円弧非表示（ドットのみ）
+- [x] ビルド検証 (`pnpm run lint && pnpm run build`)
+- [x] コミット & プッシュ
+

--- a/docs/heading_permission_and_marker/walkthrough.md
+++ b/docs/heading_permission_and_marker/walkthrough.md
@@ -1,0 +1,28 @@
+# Walkthrough: 方位許可バナー & Google Maps風マーカー
+
+## 変更内容
+
+### [OkutamaMap2D.tsx](file:///Users/hirosuke/ghq/github.com/hirosukedayo/kotei-lens/src/components/map/OkutamaMap2D.tsx)
+
+render_diffs(file:///Users/hirosuke/ghq/github.com/hirosukedayo/kotei-lens/src/components/map/OkutamaMap2D.tsx)
+
+#### 1. 方位許可バナー
+- `headingPermission` ステートで許可状態を管理（`unknown` / `prompt` / `granted` / `denied`）
+- iOS（`DeviceOrientationEvent.requestPermission`が必要）の場合、画面上部に「🧭 方位を有効にする」ボタンを表示
+- ユーザータップで許可リクエスト → 許可取得後にセンサー再起動
+
+#### 2. Google Maps風マーカー
+- 中心に青い丸 (`#4285F4`) + 白い縁取り
+- 方位許可あり: 視野方向にグラデーション扇形（70度）が広がる
+- 方位許可なし: 青い丸のみ表示
+
+## 検証結果
+
+| 項目 | 結果 |
+|------|------|
+| `pnpm run lint` | ✅ |
+| `pnpm run build` | ✅ |
+
+## ブランチ
+
+`feat/heading-permission-and-marker-style` にプッシュ済み。

--- a/src/components/map/OkutamaMap2D.tsx
+++ b/src/components/map/OkutamaMap2D.tsx
@@ -89,11 +89,11 @@ const CurrentLocationMarker = ({
 
     return L.divIcon({
       html: `
-        <div style="position: relative; width: 60px; height: 60px; display: flex; align-items: center; justify-content: center;">
+        <div style="position: relative; width: 120px; height: 120px; display: flex; align-items: center; justify-content: center;">
           <svg
             viewBox="0 0 100 100"
-            width="60"
-            height="60"
+            width="120"
+            height="120"
             style="
               overflow: visible;
               filter: drop-shadow(0 1px 3px rgba(0,0,0,0.25));
@@ -115,8 +115,8 @@ const CurrentLocationMarker = ({
         </div>
       `,
       className: 'gps-marker',
-      iconSize: [60, 60],
-      iconAnchor: [30, 30],
+      iconSize: [120, 120],
+      iconAnchor: [60, 60],
     });
   }, [gps, compassHeading, hasHeading]);
 

--- a/src/components/ui/CompassCalibration.tsx
+++ b/src/components/ui/CompassCalibration.tsx
@@ -11,6 +11,10 @@ interface CompassCalibrationProps {
     orientation: DeviceOrientation | null;
     compassHeading: number | null;
     allowManualAdjustment?: boolean;
+    /** trueの場合、自動調整を飛ばして手動モードから開始する */
+    startInManualMode?: boolean;
+    /** スライダー操作時にリアルタイムでオフセットを通知するコールバック */
+    onOffsetChange?: (offset: number) => void;
 }
 
 type CalibrationStep = 'intro' | 'horizontal' | 'manual' | 'complete';
@@ -22,9 +26,11 @@ export default function CompassCalibration({
     orientation,
     compassHeading,
     allowManualAdjustment = true,
+    startInManualMode = false,
+    onOffsetChange,
 }: CompassCalibrationProps) {
     // const { sensorData } = useSensors(); // 親からデータを受け取るため削除
-    const [step, setStep] = useState<CalibrationStep>('horizontal');
+    const [step, setStep] = useState<CalibrationStep>(startInManualMode ? 'manual' : 'horizontal');
     const [manualOffset, setManualOffset] = useState(initialOffset);
     const [isHorizontal, setIsHorizontal] = useState(false);
     const [stabilityProgress, setStabilityProgress] = useState(0);
@@ -138,7 +144,7 @@ export default function CompassCalibration({
                     <div style={{ position: 'fixed', top: '16px', right: '16px', pointerEvents: 'auto', zIndex: 30001 }}>
                         <button
                             type="button"
-                            onClick={() => setStep('horizontal')}
+                            onClick={() => startInManualMode ? onClose?.() : setStep('horizontal')}
                             style={{
                                 width: 56,
                                 height: 56,
@@ -153,7 +159,7 @@ export default function CompassCalibration({
                                 cursor: 'pointer',
                             }}
                         >
-                            <FaArrowLeft size={22} />
+                            {startInManualMode ? <IoCloseOutline size={28} /> : <FaArrowLeft size={22} />}
                         </button>
                     </div>
 
@@ -196,7 +202,11 @@ export default function CompassCalibration({
                                 min="-180"
                                 max="180"
                                 value={manualOffset}
-                                onChange={(e) => setManualOffset(Number(e.target.value))}
+                                onChange={(e) => {
+                                    const newOffset = Number(e.target.value);
+                                    setManualOffset(newOffset);
+                                    onOffsetChange?.(newOffset);
+                                }}
                                 style={{ width: '100%', height: '8px', accentColor: '#48bb78', cursor: 'pointer' }}
                             />
                         </div>

--- a/src/components/viewer/Scene3D.tsx
+++ b/src/components/viewer/Scene3D.tsx
@@ -92,6 +92,8 @@ export default function Scene3D({
   const [isArBackgroundActive, setIsArBackgroundActive] = useState(true);
   // 初期位置決定後かつ権限許可後にキャリブレーションを行う
   const [isCalibrated, setIsCalibrated] = useState(false);
+  // 3Dビュー内から再調整する場合のフラグ（手動モードで直接開始）
+  const [isRecalibrating, setIsRecalibrating] = useState(false);
 
   const [isWireframe, setIsWireframe] = useState(false);
   const [isControlsVisible] = useState(false); // デフォルトで非表示
@@ -332,14 +334,18 @@ export default function Scene3D({
           onCalibrationComplete={(offset) => {
             setManualHeadingOffset(offset);
             setIsCalibrated(true);
+            setIsRecalibrating(false);
           }}
           // キャンセル時は一旦キャリブレーション済みとする（元の画面に戻るため）
-          // または、再調整ボタンから呼ばれた場合の分岐が必要だが、
-          // シンプルにウィンドウを閉じる＝キャリブレーション完了（現状維持）とみなす
-          onClose={() => setIsCalibrated(true)}
+          onClose={() => {
+            setIsCalibrated(true);
+            setIsRecalibrating(false);
+          }}
           initialOffset={manualHeadingOffset}
           orientation={sensorData.orientation}
           compassHeading={sensorData.compassHeading}
+          startInManualMode={isRecalibrating}
+          onOffsetChange={isRecalibrating ? (offset) => setManualHeadingOffset(offset) : undefined}
         />
       )}
 
@@ -1115,7 +1121,10 @@ export default function Scene3D({
         {isMobile && permissionGranted && (
           <button
             type="button"
-            onClick={() => setIsCalibrated(false)}
+            onClick={() => {
+              setIsRecalibrating(true);
+              setIsCalibrated(false);
+            }}
             style={{
               background: 'rgba(0,0,0,0.6)',
               backdropFilter: 'blur(10px)',


### PR DESCRIPTION
## 変更内容
- **方位許可バナー (2Dモード)**:
  - iOSなど方位センサー取得にユーザーアクションが必要な環境向けに、2Dマップ上部に「🧭 方位を有効にする」ボタンを実装。
  - 2D画面でもユーザーの方位をリアルタイムに反映可能に。

- **ユーザー位置マーカー (2Dモード)**:
  - アイコンデザインを変更（Google Maps風）。
  - 中心に青いドット、進行方向（方位）にグラデーション扇形を表示。
  - サイズを拡大 (120px) し、視認性を向上。

- **3Dビュー内キャリブレーション改善**:
  - 3Dビュー内の「調整」ボタンからは水平調整をスキップし、手動モードで直接開始するように変更。
  - スライダー操作時にカメラの方位回転をリアルタイムで反映（決定前に確認可能）。

## 検証
- 実機（iOS Safariなど）での動作確認を推奨。
- `pnpm run lint` pass
- `pnpm run build` pass