### PR TITLE
画像表示の改善: BASE_URL対応と縦長画像のレイアウト修正

### DIFF
--- a/src/components/ui/PinListDrawer.tsx
+++ b/src/components/ui/PinListDrawer.tsx
@@ -166,12 +166,12 @@ export default function PinListDrawer({
           transition: 'opacity 0.25s ease',
         }}
       >
-        {/* 画像表示エリア: 上部45vhに限定 */}
+        {/* 画像表示エリア: ドロワー上部に限定 */}
         <div
           style={{
-            height: '45vh',
+            height: '50vh',
             display: 'flex',
-            alignItems: 'flex-end',
+            alignItems: 'center',
             justifyContent: 'center',
             padding: 16,
             position: 'relative',
@@ -208,7 +208,7 @@ export default function PinListDrawer({
               alt={selectedPin.title}
               style={{
                 maxWidth: '100%',
-                maxHeight: 'calc(45vh - 32px)',
+                maxHeight: 'calc(50vh - 32px)',
                 objectFit: 'contain',
                 borderRadius: 8,
               }}


### PR DESCRIPTION
- 画像パスにBASE_URLを付与しGitHub Pagesでの表示を修正
- 画像エリアを中央寄せ・50vhに拡大し縦長画像がドロワーに隠れる問題を解消