### PR TITLE
ページネーションのホバー効果無効化・民話プレーヤーの初回再生修正

### DIFF
--- a/src/components/ui/PinListDrawer.tsx
+++ b/src/components/ui/PinListDrawer.tsx
@@ -101,7 +101,7 @@ export default function PinListDrawer({
       audio.removeEventListener('ended', onEnded);
       audio.pause();
     };
-  }, [folktaleTrack]);
+  }, [folktaleTrack, sheetMode]);
 
   const ftTogglePlay = useCallback(() => {
     const audio = folktaleAudioRef.current;
@@ -723,18 +723,13 @@ export default function PinListDrawer({
                         {/* 前へ */}
                         <button
                           type="button"
+                          className="pin-pager-btn"
                           disabled={!prevPin}
                           onClick={() => prevPin && onSelectPin(prevPin)}
                           aria-label="前の地点"
                           style={{
                             flex: 1,
-                            display: 'flex',
-                            alignItems: 'center',
                             gap: 6,
-                            minHeight: 0,
-                            padding: 0,
-                            border: 'none',
-                            background: 'transparent',
                             cursor: prevPin ? 'pointer' : 'default',
                             opacity: prevPin ? 1 : 0,
                           }}
@@ -772,19 +767,14 @@ export default function PinListDrawer({
                         {/* 次へ */}
                         <button
                           type="button"
+                          className="pin-pager-btn"
                           disabled={!nextPin}
                           onClick={() => nextPin && onSelectPin(nextPin)}
                           aria-label="次の地点"
                           style={{
                             flex: 1,
-                            display: 'flex',
-                            alignItems: 'center',
                             justifyContent: 'flex-end',
                             gap: 6,
-                            minHeight: 0,
-                            padding: 0,
-                            border: 'none',
-                            background: 'transparent',
                             cursor: nextPin ? 'pointer' : 'default',
                             opacity: nextPin ? 1 : 0,
                           }}

--- a/src/styles/map-controls.css
+++ b/src/styles/map-controls.css
@@ -168,6 +168,19 @@
   outline-offset: -2px;
 }
 
+/* ページネーションボタン（ホバー効果なし） */
+.pin-pager-btn {
+  all: unset;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+}
+.pin-pager-btn:hover {
+  background: transparent;
+  transform: none;
+  box-shadow: none;
+}
+
 /* Vaulがbody/htmlに付与するスタイルを完全に無効化（画面ズレ防止） */
 body[vaul-drawer-visible],
 body[vaul-drawer-visible][style] {


### PR DESCRIPTION
## Summary
- ピン詳細のページネーションボタンからホバー効果（背景色変更・浮き上がり・影）を除去
- 民話インラインプレーヤーが初回詳細表示時に再生できない不具合を修正（useEffectの依存配列にsheetModeを追加）

## Test plan
- [ ] ページネーションの前へ/次へボタンにホバー時の背景色変更・浮き上がりがないこと
- [ ] 一覧から民話付きピンの詳細を開いた際、すぐに再生ボタンが動作すること
- [ ] ページネーションでピン切り替え後も再生が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)