### PR TITLE
fix: フォークでもGitHub Pagesが動作するようbase pathを動的化

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Build
         run: pnpm build
+        env:
+          VITE_BASE_PATH: /${{ github.event.repository.name }}/
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,7 +20,7 @@ export default defineConfig(({ command }) => ({
       },
     },
   ],
-  base: command === 'serve' ? '/' : '/kotei-lens/',
+  base: command === 'serve' ? '/' : (process.env.VITE_BASE_PATH || '/kotei-lens/'),
   resolve: {
     alias: {
       '@': resolve(__dirname, 'src'),


### PR DESCRIPTION
## Summary
- `deploy.yml` で `github.event.repository.name` からベースパスを自動設定
- `vite.config.ts` で環境変数 `VITE_BASE_PATH` を参照し、未設定時は `/kotei-lens/` にフォールバック
- フォーク先でもコード変更なしで GitHub Pages が正しく動作するように

## Test plan
- [ ] 元リポジトリ（kotei-lens）で GitHub Pages デプロイが正常に動作すること
- [ ] フォーク先リポジトリで GitHub Pages デプロイ時に404にならないこと
- [ ] ローカル開発（`pnpm dev`）が引き続き `/` ベースで動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)