### PR TITLE
fix: 体験エリアを奥多摩湖全体に拡大

### DIFF
--- a/src/services/sensors/LocationService.ts
+++ b/src/services/sensors/LocationService.ts
@@ -21,10 +21,10 @@ export class LocationService {
 
   // 奥多摩湖周辺の座標範囲（湖全体＋周辺道路をカバー）
   private readonly OKUTAMA_BOUNDS = {
-    north: 35.81,
-    south: 35.765,
+    north: 35.83,
+    south: 35.73,
     east: 139.07,
-    west: 138.99,
+    west: 138.91,
   };
 
   constructor(customOptions?: Partial<GPSOptions>) {


### PR DESCRIPTION
## Summary
- 3Dモードが有効になる体験エリアをダム堤体付近(約1km四方)から奥多摩湖全体+周辺道路に拡大
- 南端35.73〜北端35.83、西端138.91〜東端139.07をカバー

## Test plan
- [ ] 奥多摩湖周辺の各地点(小河内神社、留浦、峰谷橋、ドラム缶橋等)でエリア内判定されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)