### PR TITLE
fix: ピン詳細ドロワーのスクロール・音声再生を修正

### DIFF
--- a/src/components/ui/PinListDrawer.tsx
+++ b/src/components/ui/PinListDrawer.tsx
@@ -140,6 +140,11 @@ export default function PinListDrawer({
     };
   }, [folktaleTrack, sheetMode]);
 
+  const stopSpeech = useCallback(() => {
+    window.speechSynthesis.cancel();
+    setIsSpeaking(false);
+  }, []);
+
   const ftTogglePlay = useCallback(() => {
     const audio = folktaleAudioRef.current;
     if (!audio) return;
@@ -164,11 +169,6 @@ export default function PinListDrawer({
     const rect = bar.getBoundingClientRect();
     const ratio = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
     audio.currentTime = ratio * audio.duration;
-  }, []);
-
-  const stopSpeech = useCallback(() => {
-    window.speechSynthesis.cancel();
-    setIsSpeaking(false);
   }, []);
 
   const toggleSpeech = useCallback(() => {

--- a/src/components/ui/PinListDrawer.tsx
+++ b/src/components/ui/PinListDrawer.tsx
@@ -210,6 +210,7 @@ export default function PinListDrawer({
       setSheetMode('pin-detail');
       setImageOpen(!!selectedPin.image);
       stopSpeech();
+      scrollRef.current?.scrollTo(0, 0);
     } else {
       setImageOpen(false);
     }

--- a/src/components/ui/PinListDrawer.tsx
+++ b/src/components/ui/PinListDrawer.tsx
@@ -144,11 +144,12 @@ export default function PinListDrawer({
     const audio = folktaleAudioRef.current;
     if (!audio) return;
     if (audio.paused) {
+      stopSpeech();
       audio.play().catch(() => {});
     } else {
       audio.pause();
     }
-  }, []);
+  }, [stopSpeech]);
 
   const ftSkip = useCallback((seconds: number) => {
     const audio = folktaleAudioRef.current;
@@ -176,6 +177,10 @@ export default function PinListDrawer({
       return;
     }
     if (!selectedPin) return;
+    const audio = folktaleAudioRef.current;
+    if (audio && !audio.paused) {
+      audio.pause();
+    }
     const text = selectedPin.reading ?? `${selectedPin.title}。${selectedPin.description}`;
     const utterance = new SpeechSynthesisUtterance(text);
     utterance.lang = 'ja-JP';


### PR DESCRIPTION
## Summary
- ピン詳細を切り替えたときにスクロール位置が先頭にリセットされるよう修正
- 民話オーディオと自動読み上げ（speechSynthesis）が同時再生されないよう排他制御を追加

## Test plan
- [x] 記事を下までスクロール後、別の記事に移動するとトップから表示される
- [x] 民話再生中に読み上げボタンを押すと民話が停止し読み上げが開始される
- [x] 読み上げ中に民話再生ボタンを押すと読み上げが停止し民話が再生される

🤖 Generated with [Claude Code](https://claude.com/claude-code)