### PR TITLE
fix: 地図の最大ズームで地図が消える問題を修正

### DIFF
--- a/src/components/map/OkutamaMap2D.tsx
+++ b/src/components/map/OkutamaMap2D.tsx
@@ -773,6 +773,8 @@ export default function OkutamaMap2D({
         <TileLayer
           url="https://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}{r}.png"
           className="base-tiles"
+          maxNativeZoom={18}
+          maxZoom={20}
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/">CARTO</a>'
         />
         {/* オーバーレイ: ローカル歴史タイル（opacity は UI で調整） */}


### PR DESCRIPTION
## Summary
- CARTOベースマップのタイルがズーム18までしか提供されておらず、ズーム19以上で地図が消える問題を修正
- `maxNativeZoom={18}` を設定し、ズーム19〜20ではズーム18のタイルを拡大表示するように対応

## Test plan
- [ ] ズーム20まで拡大しても地図が消えないことを確認
- [ ] ローカル歴史タイルも正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)