### PR TITLE
fix: 2D→3D切替時に画像オーバーレイが残るバグを修正

### DIFF
--- a/src/components/map/OkutamaMap2D.tsx
+++ b/src/components/map/OkutamaMap2D.tsx
@@ -503,6 +503,9 @@ export default function OkutamaMap2D({
   };
 
   const transitionTo3D = (headingOffset?: number) => {
+    // 3D遷移前にドロワーを閉じる（画像オーバーレイもドロワー閉じに連動して解除される）
+    setSheetOpen(false);
+
     const [targetLat, targetLng] = get3DTargetPosition();
     const initialPosition: Initial3DPosition = {
       latitude: targetLat,

--- a/src/components/ui/PinListDrawer.tsx
+++ b/src/components/ui/PinListDrawer.tsx
@@ -221,10 +221,11 @@ export default function PinListDrawer({
     }
   }, [selectedPin, setSheetMode, setImageOpen, stopSpeech]);
 
-  // ドロワーが閉じられたら音声を停止しプレーヤーをリセット（スワイプ閉じ等あらゆるケースに対応）
+  // ドロワーが閉じられたら音声を停止しプレーヤーをリセット、画像オーバーレイも閉じる（スワイプ閉じ等あらゆるケースに対応）
   React.useEffect(() => {
     if (!open) {
       stopSpeech();
+      setImageOpen(false);
       const audio = folktaleAudioRef.current;
       if (audio) {
         audio.pause();
@@ -233,7 +234,7 @@ export default function PinListDrawer({
       setFtPlaying(false);
       setFtCurrentTime(0);
     }
-  }, [open, stopSpeech]);
+  }, [open, stopSpeech, setImageOpen]);
 
   // Vaulの仕様でbodyにpointer-events: noneが付与されるのを防ぐ
   React.useEffect(() => {


### PR DESCRIPTION
## Summary
- 2Dモードで画像付きピンを表示した状態で3Dモードに切り替えると、画像オーバーレイが画面上に残り続けるバグを修正
- 3D遷移前にドロワーを閉じるように変更（`transitionTo3D`）
- ドロワー閉じ時に画像オーバーレイも確実にリセットするように修正（`PinListDrawer` の `useEffect(!open)`）

## Test plan
- [ ] 2Dで画像付きピンを開いた状態で3Dモードに切り替え、画像が残らないことを確認
- [ ] 3Dから2Dに戻った際にも画像が残っていないことを確認
- [ ] 通常のドロワー操作（スワイプ閉じ等）で画像が正しく閉じることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)