### PR TITLE
feat: robots.txt を環境変数で制御し本番のみインデックス許可

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,7 @@ jobs:
         env:
           VITE_BASE_PATH: /${{ github.event.repository.name }}/
           VITE_GA_MEASUREMENT_ID: ${{ secrets.VITE_GA_MEASUREMENT_ID }}
+          VITE_ALLOW_INDEXING: ${{ vars.VITE_ALLOW_INDEXING }}
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="1957年、小河内ダムの完成により湖底に沈んだ小河内村。スマホをかざすと、かつての集落や暮らしが浮かび上がる。インタビュー・民話・伝統芸能など、失われゆく記憶を現代に蘇らせるプロジェクト。" />
-    <meta name="robots" content="noindex, nofollow" />
+    <!-- __ROBOTS_META__ -->
     <title>小河内タイムレンズ</title>
     <!-- __GA_SCRIPT__ -->
   </head>

--- a/minwa/index.html
+++ b/minwa/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
-    <meta name="robots" content="noindex, nofollow" />
+    <!-- __ROBOTS_META__ -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,0 @@
-User-agent: *
-Disallow: /
-
-

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,29 @@ import react from '@vitejs/plugin-react';
 import basicSsl from '@vitejs/plugin-basic-ssl';
 import { resolve } from 'path';
 
+function robotsMeta(): Plugin {
+  const allowIndexing = process.env.VITE_ALLOW_INDEXING === 'true';
+  return {
+    name: 'robots-meta',
+    transformIndexHtml(html) {
+      const tag = allowIndexing
+        ? '<meta name="robots" content="index, follow" />'
+        : '<meta name="robots" content="noindex, nofollow" />';
+      return html.replace('<!-- __ROBOTS_META__ -->', tag);
+    },
+    generateBundle() {
+      const content = allowIndexing
+        ? 'User-agent: *\nAllow: /\n'
+        : 'User-agent: *\nDisallow: /\n';
+      this.emitFile({
+        type: 'asset',
+        fileName: 'robots.txt',
+        source: content,
+      });
+    },
+  };
+}
+
 function googleAnalytics(): Plugin {
   const measurementId = process.env.VITE_GA_MEASUREMENT_ID;
   return {
@@ -23,6 +46,7 @@ export default defineConfig(({ command }) => ({
   plugins: [
     react(),
     basicSsl(),
+    robotsMeta(),
     googleAnalytics(),
     {
       name: 'mpa-rewrite',


### PR DESCRIPTION
## Summary
- 本番環境(code-for-okutamaフォーク)のみ検索エンジンのインデックスを許可し、開発環境ではブロックを維持
- `VITE_ALLOW_INDEXING` 環境変数でビルド時に `robots.txt` と `<meta name="robots">` を切り替える vite プラグインを追加
- GA と同じパターンで一貫性のある実装

## 変更内容
| ファイル | 変更 |
|---------|------|
| `vite.config.ts` | `robotsMeta()` プラグイン追加 |
| `index.html` / `minwa/index.html` | meta robots → プレースホルダ化 |
| `public/robots.txt` | 削除（ビルド時生成に移行） |
| `deploy.yml` | `VITE_ALLOW_INDEXING` 変数追加 |

## フォーク先での設定手順
code-for-okutama リポジトリで **Settings → Secrets and variables → Actions → Variables** に `VITE_ALLOW_INDEXING` = `true` を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)