### PR TITLE
feat: 本番環境でdevModeへの遷移を無効化

### DIFF
--- a/src/stores/devMode.ts
+++ b/src/stores/devMode.ts
@@ -7,12 +7,18 @@ interface DevModeState {
   setDevMode: (enabled: boolean) => void;
 }
 
+const isProduction = import.meta.env.VITE_ALLOW_INDEXING === 'true';
+
 export const useDevModeStore = create<DevModeState>()(
   persist(
     (set) => ({
       isDevMode: false,
-      toggleDevMode: () => set((state) => ({ isDevMode: !state.isDevMode })),
-      setDevMode: (enabled: boolean) => set({ isDevMode: enabled }),
+      toggleDevMode: () => {
+        if (!isProduction) set((state) => ({ isDevMode: !state.isDevMode }));
+      },
+      setDevMode: (enabled: boolean) => {
+        if (!isProduction) set({ isDevMode: enabled });
+      },
     }),
     {
       name: 'dev-mode-storage',


### PR DESCRIPTION
## Summary
- 本番環境（code-for-okutama フォーク）でデバッグモードに入れないようにする
- `VITE_ALLOW_INDEXING=true` の場合、`toggleDevMode` / `setDevMode` を無効化
- 開発環境（変数未設定）は従来通り右下連続タップで devMode に入れる

## 変更ファイル
- `src/stores/devMode.ts` のみ

## 前提
- #189 （`VITE_ALLOW_INDEXING` 環境変数の導入）がマージ済みであること

🤖 Generated with [Claude Code](https://claude.com/claude-code)