### PR TITLE
feat: 本番UX改善（3Dブロック・キャンセル・画像ローダー）

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -191,6 +191,7 @@ function App() {
       <SensorPermissionRequest
         onPermissionsGranted={handlePermissionsGranted}
         onPermissionsDenied={handlePermissionsDenied}
+        onCancel={handleBackTo2D}
       />
     );
   }

--- a/src/components/ui/SensorPermissionRequest.tsx
+++ b/src/components/ui/SensorPermissionRequest.tsx
@@ -8,11 +8,13 @@ import { FaMapMarkerAlt, FaCompass, FaWalking, FaCheck, FaInfoCircle, FaCamera }
 interface SensorPermissionRequestProps {
   onPermissionsGranted: () => void;
   onPermissionsDenied?: (errors: string[]) => void;
+  onCancel?: () => void;
 }
 
 export default function SensorPermissionRequest({
   onPermissionsGranted,
   onPermissionsDenied, // used for future error handling
+  onCancel,
 }: SensorPermissionRequestProps) {
   const [sensorStatus, setSensorStatus] = useState<SensorStatus>({
     gps: { available: false, permission: 'unknown', lastUpdate: null, error: null },
@@ -313,6 +315,16 @@ export default function SensorPermissionRequest({
           >
             {isAllGranted ? '開始する' : '許可せずに開始'}
           </button>
+
+          {onCancel && (
+            <button
+              type="button"
+              className="modal-btn-skip"
+              onClick={onCancel}
+            >
+              キャンセル
+            </button>
+          )}
 
           <button
             type="button"


### PR DESCRIPTION
## Summary
- 本番環境で3Dモード遷移時に「準備中」モーダルを表示し、センサー許可画面に進まずブロック
- センサー許可画面にキャンセルボタンを追加し、2Dマップに戻れるように改善
- ピン詳細の画像切替時にスピナーローダーを表示し、前画像のちらつきを防止
- 画像表示エリアのリサイズにスムーズなアニメーション（transition）を追加

## Test plan
- [ ] 本番環境（`VITE_ALLOW_INDEXING=true`）で3Dボタン押下時に「準備中」モーダルが表示される
- [ ] モーダルのOKボタン・背景タップで2Dマップに戻れる
- [ ] センサー許可画面でキャンセルボタンが表示され、2Dマップに戻れる
- [ ] ピン切替時に前の画像がちらつかず、ローダーが表示される
- [ ] 画像表示エリアのサイズ変更がスムーズにアニメーションする
- [ ] 開発環境では従来通り3Dモードに遷移可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)