### PR TITLE
fix: ドロワー戻るボタンでピン選択を解除

### DIFF
--- a/src/components/ui/PinListDrawer.tsx
+++ b/src/components/ui/PinListDrawer.tsx
@@ -226,7 +226,9 @@ export default function PinListDrawer({
     if (!open) {
       stopSpeech();
       setImageOpen(false);
-      onDeselectPin();
+      const deselectTimer = setTimeout(() => {
+        onDeselectPin();
+      }, 300);
       const audio = folktaleAudioRef.current;
       if (audio) {
         audio.pause();
@@ -234,6 +236,7 @@ export default function PinListDrawer({
       }
       setFtPlaying(false);
       setFtCurrentTime(0);
+      return () => clearTimeout(deselectTimer);
     }
   }, [open, stopSpeech, setImageOpen, onDeselectPin]);
 

--- a/src/components/ui/PinListDrawer.tsx
+++ b/src/components/ui/PinListDrawer.tsx
@@ -226,6 +226,7 @@ export default function PinListDrawer({
     if (!open) {
       stopSpeech();
       setImageOpen(false);
+      onDeselectPin();
       const audio = folktaleAudioRef.current;
       if (audio) {
         audio.pause();
@@ -234,7 +235,7 @@ export default function PinListDrawer({
       setFtPlaying(false);
       setFtCurrentTime(0);
     }
-  }, [open, stopSpeech, setImageOpen]);
+  }, [open, stopSpeech, setImageOpen, onDeselectPin]);
 
   // Vaulの仕様でbodyにpointer-events: noneが付与されるのを防ぐ
   React.useEffect(() => {

--- a/src/components/ui/PinListDrawer.tsx
+++ b/src/components/ui/PinListDrawer.tsx
@@ -265,6 +265,7 @@ export default function PinListDrawer({
     setSheetMode('pin-list');
     setImageOpen(false);
     stopSpeech();
+    onDeselectPin();
   };
 
   const handleOpenChange = (isOpen: boolean) => {


### PR DESCRIPTION
## Summary
- ドロワーの戻るボタン（←）押下時に、ピン一覧に戻ると同時にピン選択も解除するように修正
- 従来は `pin-list` モードに戻るだけで選択状態が維持されていた

## Test plan
- [ ] ピン詳細表示中に戻るボタンを押すと、ピン一覧に戻りマップ上の選択も解除される
- [ ] 画像オーバーレイ・音声再生も正しく停止される

🤖 Generated with [Claude Code](https://claude.com/claude-code)