### PR TITLE
fix: ピン詳細のタイトルを2行まで表示

### DIFF
--- a/src/components/ui/PinListDrawer.tsx
+++ b/src/components/ui/PinListDrawer.tsx
@@ -463,10 +463,12 @@ export default function PinListDrawer({
                         fontWeight: 700,
                         color: '#111827',
                         lineHeight: 1.35,
-                        whiteSpace: 'nowrap',
                         overflow: 'hidden',
                         textOverflow: 'ellipsis',
                         textAlign: 'left',
+                        display: '-webkit-box',
+                        WebkitLineClamp: 2,
+                        WebkitBoxOrient: 'vertical',
                       }}
                     >
                       {selectedPin.title}


### PR DESCRIPTION
## Summary
- ピン詳細ヘッダーのタイトルが1行で省略されていたのを、2行まで折り返して表示するように変更
- 3行以上の場合は従来通り `...` で省略

## Test plan
- [ ] 長いタイトルのピンで2行まで表示されることを確認
- [ ] 短いタイトルは従来通り1行で表示される
- [ ] 3行以上になる場合は `...` で省略される

🤖 Generated with [Claude Code](https://claude.com/claude-code)