### PR TITLE
fix: 画像ローダーの位置ずれを修正

### DIFF
--- a/src/components/ui/PinListDrawer.tsx
+++ b/src/components/ui/PinListDrawer.tsx
@@ -356,11 +356,11 @@ export default function PinListDrawer({
           {selectedPin?.image && !imageLoaded && (
             <div
               style={{
+                position: 'absolute',
+                inset: 0,
                 display: 'flex',
-                flexDirection: 'column',
                 alignItems: 'center',
                 justifyContent: 'center',
-                gap: 12,
               }}
             >
               <div


### PR DESCRIPTION
## Summary
- 画像オーバーレイのスピナーを絶対位置配置に変更
- 画像ロード前後でスピナーと画像の位置が左右にずれる問題を修正

## Test plan
- [ ] ピン切替時にスピナーが中央に表示され、画像出現時に位置がずれない
- [ ] 画像ロード完了後にスムーズにフェードインする

🤖 Generated with [Claude Code](https://claude.com/claude-code)