### PR TITLE
3D描画改善: ライティング・カメラ操作・ピン表示

### DIFF
--- a/src/components/3d/LakeModel.tsx
+++ b/src/components/3d/LakeModel.tsx
@@ -101,21 +101,22 @@ const loadFbxModel = (path: string): Promise<THREE.Group> => {
               mesh.scale.set(1, 1, 1);
               mesh.updateMatrix();
 
-              // 頂点カラーの適用
+              // マテリアルの設定（頂点カラー＋テクスチャの両方を活用）
               const hasVertexColors = mesh.geometry.hasAttribute('color');
-              if (hasVertexColors) {
-                const applyVertexColor = (mat: THREE.Material) => {
-                  if (mat instanceof THREE.MeshStandardMaterial || mat instanceof THREE.MeshPhongMaterial || mat instanceof THREE.MeshLambertMaterial) {
+              const applyMaterialSettings = (mat: THREE.Material) => {
+                if (mat instanceof THREE.MeshStandardMaterial || mat instanceof THREE.MeshPhongMaterial || mat instanceof THREE.MeshLambertMaterial) {
+                  if (hasVertexColors) {
                     mat.vertexColors = true;
-                    mat.color.set(0xffffff); // 頂点カラーがそのまま出るように白に
-                    mat.needsUpdate = true;
+                    mat.color.set(0xffffff); // ベースカラーを白にして頂点カラー・テクスチャをそのまま反映
                   }
-                };
-                if (Array.isArray(mesh.material)) {
-                  mesh.material.forEach(applyVertexColor);
-                } else {
-                  applyVertexColor(mesh.material);
+                  mat.needsUpdate = true;
+                  console.log(`[LakeModel] Material for "${mesh.name}": vertexColors=${hasVertexColors}, map=${!!mat.map}, type=${mat.type}`);
                 }
+              };
+              if (Array.isArray(mesh.material)) {
+                mesh.material.forEach(applyMaterialSettings);
+              } else {
+                applyMaterialSettings(mesh.material);
               }
             }
           }


### PR DESCRIPTION
## Summary
- PCカメラ操作をFPS方式からOrbitControlsに変更（マウスドラッグ回転・ホイールズーム・右クリックパン）
- ライティングを自然な構成に修正（太陽光角度・Environment preset・ambient強度のバランス調整）
- fogの効果を緩和し、色を空に馴染む薄青に変更
- 2km以上離れたピンを非表示にして視認性を向上
- マテリアル設定を頂点カラー＋テクスチャ両対応に整理

## Test plan
- [ ] PCブラウザでOrbitControlsによるカメラ操作（回転・ズーム・パン）が動作すること
- [ ] モバイルでは従来通りのデバイス向きカメラが動作すること
- [ ] ライティングが自然な見た目になっていること
- [ ] 遠方のピンが2km以上で非表示になること
- [ ] fogが以前より薄く、ラベルが読みやすいこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)