### PR TITLE
本番環境で3Dモードを有効化 & readingドキュメント追加

### DIFF
--- a/docs/readings.md
+++ b/docs/readings.md
@@ -1,0 +1,53 @@
+# reading（読み上げテキスト）の生成・適用手順
+
+ピンデータにはTTS（音声読み上げ）用の `reading` フィールドがあります。難読地名・固有名詞をひらがなに変換したテキストで、Gemini API を使って生成します。
+
+## 前提条件
+
+- `GEMINI_API_KEY` 環境変数が必要（Google AI Studio で取得）
+
+## 手順
+
+### 1. reading の生成
+
+```bash
+GEMINI_API_KEY=xxx node scripts/generate-readings.mjs
+```
+
+- `src/data/okutama-pins.ts` から `description` が空でないピンを抽出
+- Gemini API でタイトル＋説明文の読み上げテキストを生成
+- 結果は `scripts/readings.json` に保存される
+- **既に `readings.json` が存在する場合、未生成のピンのみ追加生成する**（途中で中断しても再開可能）
+
+### 2. 全件再生成する場合
+
+`description` を更新した場合など、全件再生成が必要なときは `readings.json` を削除してから実行します。
+
+```bash
+rm scripts/readings.json
+GEMINI_API_KEY=xxx node scripts/generate-readings.mjs
+```
+
+### 3. 生成結果の確認
+
+長文のピンでは出力が途中で切れることがあります。末尾が `。` `」` `）` で終わっていないエントリがないか確認してください。
+
+切れているものがあれば、`readings.json` から該当IDのエントリを削除して再度 `generate-readings.mjs` を実行すると、そのピンだけ再生成されます。
+
+### 4. okutama-pins.ts への反映
+
+```bash
+node scripts/apply-readings.mjs
+```
+
+- `readings.json` の内容を `okutama-pins.ts` の各ピンオブジェクトに `reading` フィールドとして挿入
+- 既に `reading` がある場合は上書き更新
+
+## 関連ファイル
+
+| ファイル | 役割 |
+|---------|------|
+| `scripts/generate-readings.mjs` | Gemini API で reading を生成 |
+| `scripts/apply-readings.mjs` | readings.json を okutama-pins.ts に反映 |
+| `scripts/readings.json` | 生成済み reading のキャッシュ（ID → テキスト） |
+| `src/types/pins.ts` | `PinData.reading` の型定義 |

--- a/src/components/map/OkutamaMap2D.tsx
+++ b/src/components/map/OkutamaMap2D.tsx
@@ -5,7 +5,7 @@ import MarkerClusterGroup from 'react-leaflet-cluster';
 import type { LatLngExpression, LatLngBoundsExpression, Map as LeafletMap } from 'leaflet';
 import L from 'leaflet';
 import { FaListUl, FaLocationArrow, FaMapMarkerAlt, FaCompass, FaPlus, FaMinus } from 'react-icons/fa';
-import { PiCubeFocusFill, PiWrenchFill } from 'react-icons/pi';
+import { PiCubeFocusFill } from 'react-icons/pi';
 import SensorPermissionRequest from '../ui/SensorPermissionRequest';
 import { useSensors } from '../../hooks/useSensors';
 import CompassCalibration from '../ui/CompassCalibration';
@@ -485,15 +485,8 @@ export default function OkutamaMap2D({
     }
   }, [sensorManager.orientationService]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const [showComingSoonModal, setShowComingSoonModal] = useState(false);
-
   // 3D切替: クリック時にまず2Dマップを初期位置に移動し、その後権限確認へ
   const handleRequest3DWithPermission = async () => {
-    if (import.meta.env.VITE_ALLOW_INDEXING === 'true') {
-      setShowComingSoonModal(true);
-      return;
-    }
-
     preloadLakeModel();
 
     const [targetLat, targetLng] = get3DTargetPosition();
@@ -1194,53 +1187,6 @@ export default function OkutamaMap2D({
         />
       )}
       {/* 本番環境 3Dモード準備中モーダル */}
-      {showComingSoonModal && (
-        <div
-          aria-labelledby="coming-soon-modal-title"
-          style={{
-            position: 'fixed',
-            inset: 0,
-            zIndex: 30000,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            background: 'rgba(0, 0, 0, 0.5)',
-            backdropFilter: 'blur(4px)',
-          }}
-          onClick={() => setShowComingSoonModal(false)}
-          onKeyDown={(e) => {
-            if (e.key === 'Escape') setShowComingSoonModal(false);
-          }}
-        >
-          <div
-            style={{
-              background: '#ffffff',
-              borderRadius: 16,
-              padding: '32px 28px 24px',
-              maxWidth: 'min(380px, 88vw)',
-              boxShadow: '0 24px 48px rgba(0, 0, 0, 0.2)',
-              textAlign: 'center',
-            }}
-            onClick={(e) => e.stopPropagation()}
-            onKeyDown={() => {}}
-          >
-            <div style={{ marginBottom: 12 }}><PiWrenchFill size={32} color="#3b82f6" /></div>
-            <h3 id="coming-soon-modal-title" style={{ margin: '0 0 12px', fontSize: '17px', fontWeight: 700, color: '#111827', lineHeight: 1.4 }}>
-              3Dビューは準備中です
-            </h3>
-            <p style={{ margin: '0 0 24px', fontSize: '14px', color: '#6b7280', lineHeight: 1.7 }}>
-              現在調整中です。<br />リリースまでもう少しお待ちください！
-            </p>
-            <button
-              type="button"
-              className="modal-btn-primary"
-              onClick={() => setShowComingSoonModal(false)}
-            >
-              OK
-            </button>
-          </div>
-        </div>
-      )}
     </div >
   );
 }


### PR DESCRIPTION
## Summary
- 本番環境（`VITE_ALLOW_INDEXING=true`）で3Dモードへの遷移をブロックしていた「準備中」モーダルを除去
- reading（読み上げテキスト）の生成・適用手順ドキュメントを `docs/readings.md` に追加

## Test plan
- [ ] 本番ビルドで2Dマップから3Dモードボタンを押して遷移できることを確認
- [ ] エリア外では3Dボタンが無効化されることを確認（既存動作の維持）

🤖 Generated with [Claude Code](https://claude.com/claude-code)