### PR TITLE
feat: 角度調整ボタン押下中のみ3Dモデルを半透明化しフェード追加

### DIFF
--- a/src/components/3d/LakeModel.tsx
+++ b/src/components/3d/LakeModel.tsx
@@ -1,6 +1,7 @@
 
 import type React from 'react';
 import { useEffect, useState, useRef, memo, useMemo, useCallback } from 'react';
+import { useFrame } from '@react-three/fiber';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import * as THREE from 'three';
 import { FBX_NORMALIZATION_TARGET } from '../../config/terrain-config';
@@ -279,9 +280,18 @@ export function LakeModel({
         // ジオメトリとマテリアルも深くクローンしてdisposeの影響を遮断
         cloned.geometry = srcMesh.geometry.clone();
         if (Array.isArray(srcMesh.material)) {
-          cloned.material = srcMesh.material.map(m => m.clone());
+          cloned.material = srcMesh.material.map(m => {
+            const mat = m.clone();
+            // 通常マテリアルはtransparentを事前に有効化（フェード時に毎フレーム設定しないため）
+            if (!(mat instanceof THREE.ShaderMaterial)) mat.transparent = true;
+            return mat;
+          });
         } else {
           cloned.material = srcMesh.material.clone();
+          // 通常マテリアルはtransparentを事前に有効化
+          if (!(cloned.material instanceof THREE.ShaderMaterial)) {
+            (cloned.material as THREE.Material).transparent = true;
+          }
         }
         meshes.push({ name: child.name, object: cloned });
         names.push(child.name);
@@ -308,25 +318,61 @@ export function LakeModel({
     updateVisibility();
   }, [hiddenObjects, updateVisibility]);
 
-  // opacity変更時に全メッシュのマテリアルに反映
+  // フェードアニメーション用ref
+  const currentOpacityRef = useRef(opacity);
+  const fromOpacityRef = useRef(opacity);
+  const targetOpacityRef = useRef(opacity);
+  const elapsedRef = useRef(0);
+  // 方向によってフェード時間を変える: 半透明化0.5秒、不透明化0.2秒
+  const fadeDurationRef = useRef(0.5);
+
+  // opacity propが変わったらアニメーション開始（値の即時適用はuseFrameに任せる）
   useEffect(() => {
+    fromOpacityRef.current = currentOpacityRef.current;
+    targetOpacityRef.current = opacity;
+    elapsedRef.current = 0;
+    fadeDurationRef.current = opacity >= currentOpacityRef.current ? 0.2 : 0.5;
+  }, [opacity]);
+
+  // 全メッシュのマテリアルに透明度を書き込む（フレームループから呼ぶためneedsUpdate不使用）
+  const applyOpacity = useCallback((v: number) => {
     for (const { object } of clonedMeshes) {
       object.traverse((child: THREE.Object3D) => {
         if (!(child instanceof THREE.Mesh) || !child.material) return;
         const materials = Array.isArray(child.material) ? child.material : [child.material];
         for (const mat of materials) {
           if (mat instanceof THREE.ShaderMaterial && mat.uniforms.uOpacity) {
-            // カスタムシェーダー（地形スプラットマテリアル）
-            mat.uniforms.uOpacity.value = opacity;
+            // カスタムシェーダー（地形スプラットマテリアル）: 値のみ更新
+            mat.uniforms.uOpacity.value = v;
           } else {
-            mat.transparent = true;
-            mat.opacity = opacity;
+            // 通常マテリアル: transparentは初回ロード時に設定済み
+            mat.opacity = v;
           }
-          mat.needsUpdate = true;
+          // needsUpdate はシェーダー再コンパイルを誘発するためフレームループ内では呼ばない
         }
       });
     }
-  }, [opacity, clonedMeshes]);
+  }, [clonedMeshes]);
+
+  // 0.5秒かけてopacityをフェード（progress-based lerp）
+  useFrame((_, delta) => {
+    const current = currentOpacityRef.current;
+    const target = targetOpacityRef.current;
+    if (Math.abs(current - target) < 0.001) return;
+
+    elapsedRef.current += delta;
+    const rawT = Math.min(1, elapsedRef.current / fadeDurationRef.current);
+    // smoothstep: 0.5秒で滑らかに完了
+    const t = rawT * rawT * (3 - 2 * rawT);
+    const v = THREE.MathUtils.lerp(fromOpacityRef.current, target, t);
+
+    currentOpacityRef.current = v;
+    applyOpacity(v);
+
+    if (rawT >= 1) {
+      currentOpacityRef.current = target;
+    }
+  });
 
   if (error) {
     return (

--- a/src/components/ar/OrientationCamera.tsx
+++ b/src/components/ar/OrientationCamera.tsx
@@ -11,11 +11,19 @@ interface OrientationCameraProps {
   manualHeadingOffset?: number; // 手動補正（度数法）
   baseHeadingOffset?: number; // キャリブレーションで算出した alpha→真北 の補正値（度数法）
   manualPitchOffset?: number; // 手動ピッチ補正（度数法）: 正=見上げ方向
+  isAdjusting?: boolean; // 角度調整ボタン押下中フラグ：trueのとき高速smoothingに切り替え
 }
 
 // 上ボタンで見上げる方向になるよう符号を調整する定数。
 // 実機で逆になる場合は -1 に変更する。
 const PITCH_SIGN = -1;
+
+// 角度調整ボタン押下中に使用する高速 smoothing 値。
+// 通常の smoothing (0.1) はセンサーノイズを滑らかにするが、
+// 手動操作中はボタンの 80ms ステップを素早く追従させるため 0.5 に切り替える。
+// 0.5 なら 80ms (≒4.8フレーム) 内に目標角の約96%に到達し、
+// 離した瞬間の残留ドリフトも体感できないレベル（約0.1°）に収まる。
+const ADJUSTING_SMOOTHING = 0.5;
 
 export default function OrientationCamera({
   deviceOrientation,
@@ -25,6 +33,7 @@ export default function OrientationCamera({
   manualHeadingOffset = 0,
   baseHeadingOffset = 0,
   manualPitchOffset = 0,
+  isAdjusting = false,
 }: OrientationCameraProps) {
   const { camera } = useThree();
 
@@ -74,6 +83,9 @@ export default function OrientationCamera({
     const gammaRad = THREE.MathUtils.degToRad(gamma);
     const orientRad = screenOrientation.current;
 
+    // 角度調整ボタン押下中は高速smoothingに切り替え、操作のキビキビ感を向上させる
+    const effectiveSmoothing = isAdjusting ? ADJUSTING_SMOOTHING : smoothing;
+
     if (arMode) {
       // DeviceOrientationControls の標準的な Quaternion 計算ロジック
       // 順序 YXZ: 'ZXY' for the device orientation
@@ -88,11 +100,11 @@ export default function OrientationCamera({
       q_final.current.multiply(q_screen.current);
 
       // 滑らかな補間
-      camera.quaternion.slerp(q_final.current, smoothing);
+      camera.quaternion.slerp(q_final.current, effectiveSmoothing);
     } else {
       // 非ARモード：シンプルな傾き表現
       euler.current.set(betaRad * 0.1, alphaRad * 0.1, 0, 'XYZ');
-      camera.quaternion.slerp(q_final.current.setFromEuler(euler.current), smoothing);
+      camera.quaternion.slerp(q_final.current.setFromEuler(euler.current), effectiveSmoothing);
     }
   });
 

--- a/src/components/ar/OrientationCamera.tsx
+++ b/src/components/ar/OrientationCamera.tsx
@@ -10,7 +10,12 @@ interface OrientationCameraProps {
   arMode?: boolean; // ARモード：背面カメラ補正を含む
   manualHeadingOffset?: number; // 手動補正（度数法）
   baseHeadingOffset?: number; // キャリブレーションで算出した alpha→真北 の補正値（度数法）
+  manualPitchOffset?: number; // 手動ピッチ補正（度数法）: 正=見上げ方向
 }
+
+// 上ボタンで見上げる方向になるよう符号を調整する定数。
+// 実機で逆になる場合は -1 に変更する。
+const PITCH_SIGN = -1;
 
 export default function OrientationCamera({
   deviceOrientation,
@@ -19,6 +24,7 @@ export default function OrientationCamera({
   arMode = false,
   manualHeadingOffset = 0,
   baseHeadingOffset = 0,
+  manualPitchOffset = 0,
 }: OrientationCameraProps) {
   const { camera } = useThree();
 
@@ -64,7 +70,7 @@ export default function OrientationCamera({
     // manualHeadingOffset: ユーザー手動微調整
     const alphaRad = THREE.MathUtils.degToRad(alpha + baseHeadingOffset + manualHeadingOffset);
 
-    const betaRad = THREE.MathUtils.degToRad(beta);
+    const betaRad = THREE.MathUtils.degToRad(beta + PITCH_SIGN * manualPitchOffset);
     const gammaRad = THREE.MathUtils.degToRad(gamma);
     const orientRad = screenOrientation.current;
 

--- a/src/components/map/OkutamaMap2D.tsx
+++ b/src/components/map/OkutamaMap2D.tsx
@@ -305,7 +305,7 @@ export default function OkutamaMap2D({
   // Devモード状態
   const { isDevMode } = useDevModeStore();
   // 段階的パーミッションステップ管理
-  type PermissionStep = 'check' | 'location' | 'heading' | 'outside' | 'done';
+  type PermissionStep = 'check' | 'location' | 'locating' | 'heading' | 'outside' | 'done';
   const [permissionStep, setPermissionStep] = useState<PermissionStep>('check');
   // エリア外かどうか (null = まだGPS未取得で未判定)
   const [isOutsideArea, setIsOutsideArea] = useState<boolean | null>(null);
@@ -558,7 +558,8 @@ export default function OkutamaMap2D({
       if (gpsPermission === 'granted') {
         startSensors();
         if (needsHeadingPrompt) {
-          setPermissionStep('heading');
+          // GPS はすでに流れているのでエリア判定を待ってから heading へ
+          setPermissionStep('locating');
         } else {
           setPermissionStep('done');
         }
@@ -585,19 +586,15 @@ export default function OkutamaMap2D({
 
   // Step 1: 位置情報の許可ボタン押下（GPSのみ開始、方位・モーションは触らない）
   const handleLocationPermissionRequest = useCallback(async () => {
-    // GPSだけを開始（startSensorsは方位やモーションも開始してOSプロンプトが出るため直接呼ぶ）
-    // useSensorsのGPSコールバックは後のステップでstartSensors経由で接続される
-    if (sensorManager.locationService.isAvailable()) {
-      sensorManager.locationService.startWatching(() => {});
-    }
-
     const orientationState = sensorManager.orientationService.getPermissionState();
     const isIOS =
       typeof window.DeviceOrientationEvent !== 'undefined' &&
       typeof (window.DeviceOrientationEvent as any).requestPermission === 'function';
     const needsHeadingPrompt = isIOS && orientationState !== 'granted';
     if (needsHeadingPrompt) {
-      setPermissionStep('heading');
+      // iOSで方位未許可: OSプロンプトなしでGPSだけ開始し、エリア判定を待つ
+      startSensors(false, false);
+      setPermissionStep('locating');
     } else {
       // 非iOS or 方位既許可 → 全センサーを開始（非iOSではOSプロンプトなし）
       startSensors(false, true);
@@ -666,6 +663,28 @@ export default function OkutamaMap2D({
       setPermissionStep('outside');
     }
   }, [isOutsideArea, permissionStep]);
+
+  // locating: GPS初回測位でエリア判定が確定したら分岐
+  // エリア外 → outside、エリア内 → heading（方位許可へ）
+  useEffect(() => {
+    if (permissionStep !== 'locating') return;
+    if (isOutsideArea === null) return; // GPS未取得のため待機継続
+    if (isOutsideArea) {
+      hasShownOutsideModalRef.current = true;
+      setPermissionStep('outside');
+    } else {
+      setPermissionStep('heading');
+    }
+  }, [permissionStep, isOutsideArea]);
+
+  // locating タイムアウト: GPSエラー等で測位できない場合に heading へフォールバック
+  useEffect(() => {
+    if (permissionStep !== 'locating') return;
+    const timer = setTimeout(() => {
+      setPermissionStep((s) => (s === 'locating' ? 'heading' : s));
+    }, 4000);
+    return () => clearTimeout(timer);
+  }, [permissionStep]);
   // public配下のタイルは Vite の base に追従して配信される
   const tilesBase = import.meta.env.BASE_URL || '/';
   const localTilesUrl = `${tilesBase}tiles/{z}/{x}/{y}.png`;
@@ -877,6 +896,42 @@ export default function OkutamaMap2D({
             >
               許可する
             </button>
+          </div>
+        </div>
+      )}
+
+      {/* Step 1.5: 現在地確認中モーダル（iOSで方位許可が必要な場合にGPS測位を待つ） */}
+      {permissionStep === 'locating' && (
+        <div
+          aria-labelledby="locating-modal-title"
+          style={{
+            position: 'fixed',
+            inset: 0,
+            zIndex: 30000,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            background: 'rgba(0, 0, 0, 0.5)',
+            backdropFilter: 'blur(4px)',
+          }}
+        >
+          <div
+            style={{
+              background: '#ffffff',
+              borderRadius: 16,
+              padding: '32px 28px 24px',
+              maxWidth: 'min(380px, 88vw)',
+              boxShadow: '0 24px 48px rgba(0, 0, 0, 0.2)',
+              textAlign: 'center',
+            }}
+          >
+            <div style={{ marginBottom: 12 }}><FaMapMarkerAlt size={32} color="#3b82f6" /></div>
+            <h3 id="locating-modal-title" style={{ margin: '0 0 12px', fontSize: '17px', fontWeight: 700, color: '#111827', lineHeight: 1.4 }}>
+              現在地を確認中…
+            </h3>
+            <p style={{ margin: 0, fontSize: '14px', color: '#6b7280', lineHeight: 1.7 }}>
+              GPS信号を受信しています。しばらくお待ちください。
+            </p>
           </div>
         </div>
       )}

--- a/src/components/map/OkutamaMap2D.tsx
+++ b/src/components/map/OkutamaMap2D.tsx
@@ -188,9 +188,9 @@ const CurrentLocationMarker = ({
             "
           >
             <defs>
-              <radialGradient id="${gradId}" cx="50%" cy="50%" r="50%" fx="50%" fy="50%">
-                <stop offset="0%" stop-color="#4285F4" stop-opacity="0.35" />
-                <stop offset="100%" stop-color="#4285F4" stop-opacity="0.03" />
+              <radialGradient id="${gradId}" gradientUnits="userSpaceOnUse" cx="${cx}" cy="${cy}" r="${r}">
+                <stop offset="0%" stop-color="#4285F4" stop-opacity="0.5" />
+                <stop offset="100%" stop-color="#4285F4" stop-opacity="0.0" />
               </radialGradient>
             </defs>
             <!-- 視野の扇形（方位連動） -->
@@ -288,7 +288,7 @@ export default function OkutamaMap2D({
   onDeselectPin: propOnDeselectPin,
 }: OkutamaMap2DProps) {
   const [sheetOpen, setSheetOpen] = useState<boolean>(false);
-  const [sheetMode, setSheetMode] = useState<'pin-list' | 'pin-detail'>('pin-list');
+  const [, setSheetMode] = useState<'pin-list' | 'pin-detail'>('pin-list');
   const [imageOverlayOpen, setImageOverlayOpen] = useState(false);
   const pinClickGuardRef = useRef(false);
   // propsから選択ピンを取得、なければローカルstateを使用
@@ -1137,30 +1137,6 @@ export default function OkutamaMap2D({
 
       </div>
 
-      {/* 画面中央：中抜き十字マーク（記事表示中はフェードアウト） */}
-      <div
-        style={{
-          position: 'absolute',
-          top: '50%',
-          left: '50%',
-          transform: 'translate(-50%, -50%)',
-          width: '30px',
-          height: '30px',
-          zIndex: 10000,
-          pointerEvents: 'none',
-          opacity: (sheetOpen && sheetMode === 'pin-detail') ? 0 : 1,
-          transition: 'opacity 0.5s ease',
-        }}
-      >
-        {/* 上 */}
-        <div style={{ position: 'absolute', top: 0, left: '50%', transform: 'translateX(-50%)', width: '2px', height: '10px', backgroundColor: 'rgba(128,128,128,0.7)', }} />
-        {/* 下 */}
-        <div style={{ position: 'absolute', bottom: 0, left: '50%', transform: 'translateX(-50%)', width: '2px', height: '10px', backgroundColor: 'rgba(128,128,128,0.7)', }} />
-        {/* 左 */}
-        <div style={{ position: 'absolute', top: '50%', left: 0, transform: 'translateY(-50%)', width: '10px', height: '2px', backgroundColor: 'rgba(128,128,128,0.7)', }} />
-        {/* 右 */}
-        <div style={{ position: 'absolute', top: '50%', right: 0, transform: 'translateY(-50%)', width: '10px', height: '2px', backgroundColor: 'rgba(128,128,128,0.7)', }} />
-      </div>
 
       {/* 左下：ピン一覧（アイコン） */}
       <div

--- a/src/components/ui/CompassCalibration.tsx
+++ b/src/components/ui/CompassCalibration.tsx
@@ -17,12 +17,10 @@ interface CompassCalibrationProps {
     startInManualMode?: boolean;
     /** スライダー操作時にリアルタイムでオフセットを通知するコールバック */
     onOffsetChange?: (offset: number) => void;
-    /** 高さオフセット初期値 */
-    initialHeightOffset?: number;
-    /** 高さスライダー操作時にリアルタイムで通知するコールバック */
-    onHeightOffsetChange?: (offset: number) => void;
-    /** 高さが下限に達しているか */
-    heightAtFloor?: boolean;
+    /** ピッチオフセット初期値（度） */
+    initialPitchOffset?: number;
+    /** ピッチ操作時にリアルタイムで通知するコールバック */
+    onPitchOffsetChange?: (offset: number) => void;
 }
 
 type CalibrationStep = 'intro' | 'horizontal' | 'manual' | 'complete';
@@ -36,15 +34,14 @@ export default function CompassCalibration({
     allowManualAdjustment = true,
     startInManualMode = false,
     onOffsetChange,
-    initialHeightOffset = 0,
-    onHeightOffsetChange,
-    heightAtFloor = false,
+    initialPitchOffset = 0,
+    onPitchOffsetChange,
 }: CompassCalibrationProps) {
     // const { sensorData } = useSensors(); // 親からデータを受け取るため削除
     const [step, setStep] = useState<CalibrationStep>(startInManualMode ? 'manual' : 'horizontal');
     const [manualDrawerOpen, setManualDrawerOpen] = useState(true);
     const [manualOffset, setManualOffset] = useState(initialOffset);
-    const [heightOffset, setHeightOffset] = useState(initialHeightOffset);
+    const [pitchOffset, setPitchOffset] = useState(initialPitchOffset);
     const [isHorizontal, setIsHorizontal] = useState(false);
     const [stabilityProgress, setStabilityProgress] = useState(0);
 
@@ -181,13 +178,15 @@ export default function CompassCalibration({
         });
     }, [onOffsetChange]);
 
-    const adjustHeight = useCallback((delta: number) => {
-        setHeightOffset(prev => {
-            const next = Math.max(-200, Math.min(200, prev + delta));
-            onHeightOffsetChange?.(next);
+    const PITCH_MAX = 30; // ピッチ調整の最大値（度）
+
+    const adjustPitch = useCallback((delta: number) => {
+        setPitchOffset(prev => {
+            const next = Math.max(-PITCH_MAX, Math.min(PITCH_MAX, prev + delta));
+            onPitchOffsetChange?.(next);
             return next;
         });
-    }, [onHeightOffsetChange]);
+    }, [onPitchOffsetChange]);
 
     const dismissManual = useCallback(() => {
         // まずDrawerを閉じ、アニメーション完了後にコールバック
@@ -233,7 +232,7 @@ export default function CompassCalibration({
                     onCloseAutoFocus={(e: Event) => e.preventDefault()}
                 >
                     <VDrawer.Title style={{ display: 'none' }}>手動調整</VDrawer.Title>
-                    <VDrawer.Description style={{ display: 'none' }}>方位と高さを手動で調整します。</VDrawer.Description>
+                    <VDrawer.Description style={{ display: 'none' }}>方位と角度を手動で調整します。</VDrawer.Description>
 
                     <div
                         style={{
@@ -255,7 +254,7 @@ export default function CompassCalibration({
                         </p>
 
                         {/* D-pad コントローラー */}
-                        <div data-vaul-no-drag style={{ position: 'relative', height: 56, marginBottom: '24px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                        <div data-vaul-no-drag style={{ position: 'relative', height: 160, marginBottom: '16px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                             {/* 左ボタン（方位-） */}
                             <button
                                 type="button"
@@ -273,45 +272,58 @@ export default function CompassCalibration({
                                 <FaChevronLeft size={20} />
                             </button>
 
-                            {/* 上ボタン（高さ+） */}
-                            <button
-                                type="button"
-                                onPointerDown={() => startHold(() => adjustHeight(2))}
-                                onPointerUp={stopHold}
-                                onPointerLeave={stopHold}
-                                onContextMenu={(e) => e.preventDefault()}
-                                style={{
-                                    position: 'absolute', left: '50%', top: -14, transform: 'translateX(-50%)',
-                                    width: 36, height: 36, minHeight: 0, padding: 0, borderRadius: '50%',
-                                    backgroundColor: 'rgba(255,255,255,0.1)', border: '2px solid rgba(255,255,255,0.25)',
-                                    color: 'rgba(255,255,255,0.7)', display: 'flex', alignItems: 'center', justifyContent: 'center',
-                                    cursor: 'pointer', touchAction: 'none', zIndex: 1,
-                                }}
-                            >
-                                <FaChevronUp size={12} />
-                            </button>
+                            {/* 上ボタン（見上げ）・中央「調整完了」・下ボタン（見下げ）の縦並び */}
+                            <div style={{ position: 'absolute', left: '50%', transform: 'translateX(-50%)', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0, top: 0, bottom: 0, justifyContent: 'space-between' }}>
+                                {/* 上ボタン（見上げ） */}
+                                <button
+                                    type="button"
+                                    onPointerDown={() => startHold(() => adjustPitch(2))}
+                                    onPointerUp={stopHold}
+                                    onPointerLeave={stopHold}
+                                    onContextMenu={(e) => e.preventDefault()}
+                                    style={{
+                                        width: 44, height: 44, minHeight: 0, padding: 0, borderRadius: '50%',
+                                        backgroundColor: 'rgba(255,255,255,0.1)', border: '2px solid rgba(255,255,255,0.25)',
+                                        color: 'rgba(255,255,255,0.7)', display: 'flex', alignItems: 'center', justifyContent: 'center',
+                                        cursor: 'pointer', touchAction: 'none',
+                                    }}
+                                >
+                                    <FaChevronUp size={16} />
+                                </button>
 
-                            {/* 下ボタン（高さ-） */}
-                            <button
-                                type="button"
-                                onPointerDown={() => { if (!heightAtFloor) startHold(() => adjustHeight(-2)); }}
-                                onPointerUp={stopHold}
-                                onPointerLeave={stopHold}
-                                onContextMenu={(e) => e.preventDefault()}
-                                style={{
-                                    position: 'absolute', left: '50%', bottom: -14, transform: 'translateX(-50%)',
-                                    width: 36, height: 36, minHeight: 0, padding: 0, borderRadius: '50%',
-                                    backgroundColor: heightAtFloor ? 'rgba(255,80,80,0.15)' : 'rgba(255,255,255,0.1)',
-                                    border: `2px solid ${heightAtFloor ? 'rgba(255,80,80,0.4)' : 'rgba(255,255,255,0.25)'}`,
-                                    color: heightAtFloor ? 'rgba(255,80,80,0.5)' : 'rgba(255,255,255,0.7)',
-                                    display: 'flex', alignItems: 'center', justifyContent: 'center',
-                                    cursor: heightAtFloor ? 'not-allowed' : 'pointer', touchAction: 'none', zIndex: 1,
-                                }}
-                            >
-                                <FaChevronDown size={12} />
-                            </button>
+                                {/* 調整完了ボタン */}
+                                <button
+                                    type="button"
+                                    onClick={dismissManual}
+                                    style={{
+                                        minHeight: 0, padding: '10px 20px', borderRadius: 24,
+                                        backgroundColor: 'rgba(255,255,255,0.15)', border: '1.5px solid rgba(255,255,255,0.4)',
+                                        color: 'rgba(255,255,255,0.9)', fontSize: '0.85rem', fontWeight: 'bold',
+                                        cursor: 'pointer', whiteSpace: 'nowrap',
+                                    }}
+                                >
+                                    調整完了
+                                </button>
 
-                            {/* 右ボタン（方位-） */}
+                                {/* 下ボタン（見下げ） */}
+                                <button
+                                    type="button"
+                                    onPointerDown={() => startHold(() => adjustPitch(-2))}
+                                    onPointerUp={stopHold}
+                                    onPointerLeave={stopHold}
+                                    onContextMenu={(e) => e.preventDefault()}
+                                    style={{
+                                        width: 44, height: 44, minHeight: 0, padding: 0, borderRadius: '50%',
+                                        backgroundColor: 'rgba(255,255,255,0.1)', border: '2px solid rgba(255,255,255,0.25)',
+                                        color: 'rgba(255,255,255,0.7)', display: 'flex', alignItems: 'center', justifyContent: 'center',
+                                        cursor: 'pointer', touchAction: 'none',
+                                    }}
+                                >
+                                    <FaChevronDown size={16} />
+                                </button>
+                            </div>
+
+                            {/* 右ボタン（方位+） */}
                             <button
                                 type="button"
                                 onPointerDown={() => startHold(() => adjustHeading(-2))}
@@ -332,12 +344,12 @@ export default function CompassCalibration({
                         {/* 補正値 + リセット */}
                         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '14px', fontSize: '0.8rem', color: 'rgba(255,255,255,0.5)' }}>
                             <span>方位 {manualOffset}°</span>
-                            <span>高さ {heightOffset > 0 ? `+${heightOffset}` : heightOffset}m</span>
+                            <span>角度 {pitchOffset > 0 ? `+${pitchOffset}` : pitchOffset}°</span>
                             <button
                                 type="button"
                                 onClick={() => {
                                     setManualOffset(0); onOffsetChange?.(0);
-                                    setHeightOffset(0); onHeightOffsetChange?.(0);
+                                    setPitchOffset(0); onPitchOffsetChange?.(0);
                                 }}
                                 style={{
                                     background: 'none', backgroundColor: 'transparent', border: 'none', minHeight: 0, padding: '2px 6px',

--- a/src/components/ui/CompassCalibration.tsx
+++ b/src/components/ui/CompassCalibration.tsx
@@ -240,21 +240,21 @@ export default function CompassCalibration({
                             backdropFilter: 'blur(10px)',
                             borderTopLeftRadius: 16,
                             borderTopRightRadius: 16,
-                            padding: '0 20px 40px',
+                            padding: '0 20px 12px',
                             color: 'white',
                         }}
                     >
                         {/* ドラッグハンドル */}
-                        <div style={{ padding: '12px 0 10px', display: 'flex', justifyContent: 'center' }}>
+                        <div style={{ padding: '8px 0 6px', display: 'flex', justifyContent: 'center' }}>
                             <div data-vaul-handle style={{ background: 'rgba(255,255,255,0.3)' }} />
                         </div>
 
-                        <p style={{ fontSize: '0.85rem', textAlign: 'center', color: 'rgba(255,255,255,0.6)', margin: '0 0 20px' }}>
+                        <p style={{ fontSize: '0.85rem', textAlign: 'center', color: 'rgba(255,255,255,0.6)', margin: '0 0 10px' }}>
                             カメラ画面と山を重ねてみよう
                         </p>
 
                         {/* D-pad コントローラー */}
-                        <div data-vaul-no-drag style={{ position: 'relative', height: 200, marginBottom: '12px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                        <div data-vaul-no-drag style={{ position: 'relative', height: 160, marginBottom: '8px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                             {/* 左ボタン（方位-） */}
                             <button
                                 type="button"
@@ -273,7 +273,7 @@ export default function CompassCalibration({
                             </button>
 
                             {/* 上ボタン（見上げ）・中央「調整完了」・下ボタン（見下げ）の縦並び */}
-                            <div style={{ position: 'absolute', left: '50%', transform: 'translateX(-50%)', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0, top: 0, bottom: 0, justifyContent: 'space-between' }}>
+                            <div style={{ position: 'absolute', left: '50%', transform: 'translateX(-50%)', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10, justifyContent: 'center', top: 0, bottom: 0 }}>
                                 {/* 上ボタン（見上げ） */}
                                 <button
                                     type="button"
@@ -282,13 +282,13 @@ export default function CompassCalibration({
                                     onPointerLeave={stopHold}
                                     onContextMenu={(e) => e.preventDefault()}
                                     style={{
-                                        width: 44, height: 44, minHeight: 0, padding: 0, borderRadius: '50%',
+                                        width: 56, height: 56, minHeight: 0, padding: 0, borderRadius: '50%',
                                         backgroundColor: 'rgba(255,255,255,0.1)', border: '2px solid rgba(255,255,255,0.25)',
                                         color: 'rgba(255,255,255,0.7)', display: 'flex', alignItems: 'center', justifyContent: 'center',
                                         cursor: 'pointer', touchAction: 'none',
                                     }}
                                 >
-                                    <FaChevronUp size={16} />
+                                    <FaChevronUp size={20} />
                                 </button>
 
                                 {/* 調整完了ボタン */}
@@ -313,13 +313,13 @@ export default function CompassCalibration({
                                     onPointerLeave={stopHold}
                                     onContextMenu={(e) => e.preventDefault()}
                                     style={{
-                                        width: 44, height: 44, minHeight: 0, padding: 0, borderRadius: '50%',
+                                        width: 56, height: 56, minHeight: 0, padding: 0, borderRadius: '50%',
                                         backgroundColor: 'rgba(255,255,255,0.1)', border: '2px solid rgba(255,255,255,0.25)',
                                         color: 'rgba(255,255,255,0.7)', display: 'flex', alignItems: 'center', justifyContent: 'center',
                                         cursor: 'pointer', touchAction: 'none',
                                     }}
                                 >
-                                    <FaChevronDown size={16} />
+                                    <FaChevronDown size={20} />
                                 </button>
                             </div>
 

--- a/src/components/ui/CompassCalibration.tsx
+++ b/src/components/ui/CompassCalibration.tsx
@@ -254,7 +254,7 @@ export default function CompassCalibration({
                         </p>
 
                         {/* D-pad コントローラー */}
-                        <div data-vaul-no-drag style={{ position: 'relative', height: 160, marginBottom: '16px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                        <div data-vaul-no-drag style={{ position: 'relative', height: 200, marginBottom: '12px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                             {/* 左ボタン（方位-） */}
                             <button
                                 type="button"
@@ -341,10 +341,12 @@ export default function CompassCalibration({
                             </button>
                         </div>
 
-                        {/* 補正値 + リセット */}
-                        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '14px', fontSize: '0.8rem', color: 'rgba(255,255,255,0.5)' }}>
-                            <span>方位 {manualOffset}°</span>
-                            <span>角度 {pitchOffset > 0 ? `+${pitchOffset}` : pitchOffset}°</span>
+                        {/* 補正値（左下）+ リセット（右下） */}
+                        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', fontSize: '0.8rem' }}>
+                            <div style={{ display: 'flex', gap: '12px', color: 'rgba(255,255,255,0.5)' }}>
+                                <span>方位 {manualOffset}°</span>
+                                <span>角度 {pitchOffset > 0 ? `+${pitchOffset}` : pitchOffset}°</span>
+                            </div>
                             <button
                                 type="button"
                                 onClick={() => {
@@ -353,7 +355,7 @@ export default function CompassCalibration({
                                 }}
                                 style={{
                                     background: 'none', backgroundColor: 'transparent', border: 'none', minHeight: 0, padding: '2px 6px',
-                                    color: 'rgba(255,255,255,0.3)', cursor: 'pointer', fontSize: '0.7rem', textDecoration: 'underline',
+                                    color: 'rgba(255,80,80,0.8)', cursor: 'pointer', fontSize: '0.75rem', textDecoration: 'underline',
                                 }}
                             >
                                 リセット

--- a/src/components/ui/CompassCalibration.tsx
+++ b/src/components/ui/CompassCalibration.tsx
@@ -21,6 +21,8 @@ interface CompassCalibrationProps {
     initialPitchOffset?: number;
     /** ピッチ操作時にリアルタイムで通知するコールバック */
     onPitchOffsetChange?: (offset: number) => void;
+    /** ボタン押下中（調整中）かどうかを通知するコールバック */
+    onAdjustingChange?: (adjusting: boolean) => void;
 }
 
 type CalibrationStep = 'intro' | 'horizontal' | 'manual' | 'complete';
@@ -36,6 +38,7 @@ export default function CompassCalibration({
     onOffsetChange,
     initialPitchOffset = 0,
     onPitchOffsetChange,
+    onAdjustingChange,
 }: CompassCalibrationProps) {
     // const { sensorData } = useSensors(); // 親からデータを受け取るため削除
     const [step, setStep] = useState<CalibrationStep>(startInManualMode ? 'manual' : 'horizontal');
@@ -157,15 +160,17 @@ export default function CompassCalibration({
             clearInterval(holdIntervalRef.current);
             holdIntervalRef.current = null;
         }
-    }, []);
+        onAdjustingChange?.(false);
+    }, [onAdjustingChange]);
 
     // クリーンアップ
     useEffect(() => stopHold, [stopHold]);
 
     const startHold = useCallback((action: () => void) => {
+        onAdjustingChange?.(true);
         action(); // 即座に1回実行
         holdIntervalRef.current = setInterval(action, 80);
-    }, []);
+    }, [onAdjustingChange]);
 
     const adjustHeading = useCallback((delta: number) => {
         setManualOffset(prev => {
@@ -261,6 +266,7 @@ export default function CompassCalibration({
                                 onPointerDown={() => startHold(() => adjustHeading(2))}
                                 onPointerUp={stopHold}
                                 onPointerLeave={stopHold}
+                                onPointerCancel={stopHold}
                                 onContextMenu={(e) => e.preventDefault()}
                                 style={{
                                     width: 56, height: 56, minHeight: 0, padding: 0, borderRadius: '50%',
@@ -280,6 +286,7 @@ export default function CompassCalibration({
                                     onPointerDown={() => startHold(() => adjustPitch(2))}
                                     onPointerUp={stopHold}
                                     onPointerLeave={stopHold}
+                                    onPointerCancel={stopHold}
                                     onContextMenu={(e) => e.preventDefault()}
                                     style={{
                                         width: 56, height: 56, minHeight: 0, padding: 0, borderRadius: '50%',
@@ -311,6 +318,7 @@ export default function CompassCalibration({
                                     onPointerDown={() => startHold(() => adjustPitch(-2))}
                                     onPointerUp={stopHold}
                                     onPointerLeave={stopHold}
+                                    onPointerCancel={stopHold}
                                     onContextMenu={(e) => e.preventDefault()}
                                     style={{
                                         width: 56, height: 56, minHeight: 0, padding: 0, borderRadius: '50%',
@@ -329,6 +337,7 @@ export default function CompassCalibration({
                                 onPointerDown={() => startHold(() => adjustHeading(-2))}
                                 onPointerUp={stopHold}
                                 onPointerLeave={stopHold}
+                                onPointerCancel={stopHold}
                                 onContextMenu={(e) => e.preventDefault()}
                                 style={{
                                     width: 56, height: 56, minHeight: 0, padding: 0, borderRadius: '50%',

--- a/src/components/viewer/Scene3D.tsx
+++ b/src/components/viewer/Scene3D.tsx
@@ -104,6 +104,7 @@ export default function Scene3D({
   const { sensorData, startSensors } = useSensors();
   const terrainPosition = useTerrainPosition();
   const [manualHeadingOffset, setManualHeadingOffset] = useState(0);
+  const [manualPitchOffset, setManualPitchOffset] = useState(0);
   const [fov, setFov] = useState(DEFAULT_FOV);
   const [showDebug, setShowDebug] = useState(false);
   const { isDevMode } = useDevModeStore();
@@ -132,7 +133,6 @@ export default function Scene3D({
   const [showCameraControls] = useState(false);
 
   const [cameraHeightOffset, setCameraHeightOffset] = useState(0);
-  const [heightAtFloor, setHeightAtFloor] = useState(false);
   const [actualCameraHeight, setActualCameraHeight] = useState<number | null>(null);
   // 地形モデル調整
   const [terrainOffsetX, setTerrainOffsetX] = useState(0);
@@ -408,9 +408,8 @@ export default function Scene3D({
           compassHeading={sensorData.compassHeading}
           startInManualMode
           onOffsetChange={(offset) => setManualHeadingOffset(offset)}
-          initialHeightOffset={cameraHeightOffset}
-          onHeightOffsetChange={(offset) => setCameraHeightOffset(offset)}
-          heightAtFloor={heightAtFloor}
+          initialPitchOffset={manualPitchOffset}
+          onPitchOffsetChange={(offset) => setManualPitchOffset(offset)}
         />
       )}
 
@@ -440,7 +439,6 @@ export default function Scene3D({
               // 少し遅延させてからReadyにする（描画安定待ち）
               setTimeout(() => setIsReady(true), 500);
             }}
-            onHeightAtFloor={setHeightAtFloor}
           />
           {/* PC用キーボード移動コントロール（OrbitControls使用時は無効） */}
           {/* {!isMobile && <PCKeyboardControls />} */}
@@ -452,6 +450,7 @@ export default function Scene3D({
               arMode={true}
               manualHeadingOffset={manualHeadingOffset}
               baseHeadingOffset={baseHeadingOffset}
+              manualPitchOffset={manualPitchOffset}
             />
           )}
 

--- a/src/components/viewer/Scene3D.tsx
+++ b/src/components/viewer/Scene3D.tsx
@@ -116,6 +116,8 @@ export default function Scene3D({
   const [isCalibrated, setIsCalibrated] = useState(false);
   // 3Dビュー内から再調整する場合のフラグ（手動モードで直接開始）
   const [isRecalibrating, setIsRecalibrating] = useState(false);
+  // D-padボタン押下中のみtrue（半透明フェードのトリガー）
+  const [isAdjustingAngle, setIsAdjustingAngle] = useState(false);
 
   const handleCameraError = useCallback(() => setIsCameraAvailable(false), []);
 
@@ -127,6 +129,7 @@ export default function Scene3D({
     }
     setIsCalibrated(true);
     setIsRecalibrating(false);
+    setIsAdjustingAngle(false);
   }, [isRecalibrating]);
 
   const [isControlsVisible] = useState(false); // デフォルトで非表示
@@ -402,6 +405,7 @@ export default function Scene3D({
           onCalibrationComplete={handleCalibrationComplete}
           onClose={() => {
             setIsRecalibrating(false);
+            setIsAdjustingAngle(false);
           }}
           initialOffset={manualHeadingOffset}
           orientation={sensorData.orientation}
@@ -410,6 +414,7 @@ export default function Scene3D({
           onOffsetChange={(offset) => setManualHeadingOffset(offset)}
           initialPitchOffset={manualPitchOffset}
           onPitchOffsetChange={(offset) => setManualPitchOffset(offset)}
+          onAdjustingChange={setIsAdjustingAngle}
         />
       )}
 
@@ -511,7 +516,7 @@ export default function Scene3D({
             })()}
             hiddenObjects={stableFbxHiddenObjects}
             onObjectsLoaded={handleFbxObjectsLoaded}
-            opacity={isRecalibrating && isArBackgroundActive && isCameraAvailable && isMobile ? CALIBRATION_MODEL_OPACITY : 1}
+            opacity={isAdjustingAngle && isArBackgroundActive && isCameraAvailable && isMobile ? CALIBRATION_MODEL_OPACITY : 1}
           />
 
           {/* 2Dマップ上のピン位置を3Dビューに表示 */}

--- a/src/components/viewer/Scene3D.tsx
+++ b/src/components/viewer/Scene3D.tsx
@@ -456,6 +456,7 @@ export default function Scene3D({
               manualHeadingOffset={manualHeadingOffset}
               baseHeadingOffset={baseHeadingOffset}
               manualPitchOffset={manualPitchOffset}
+              isAdjusting={isAdjustingAngle}
             />
           )}
 


### PR DESCRIPTION
## Summary

- エリア外スキップ・2Dマップ調整・調整ドロアー改善・ピッチ調整・半透明フェードをまとめた一連の改善

## 主な変更

- **エリア外の場合に方位許可ステップをスキップ**（ユーザーがエリア外にいる場合のUX改善）
- **2Dマップの現在地ピンと中央十字マークを調整**
- **調整ドロアーの上下ボタンをピッチ（視点角度）調整に変更**（従来は高さ調整）
- **調整ドロアーのレイアウト・ボタン位置を整理**
- **3Dモデルの半透明化をボタン押下中のみに限定＋0.5秒フェード**
  - 従来: ドロアーを開いている間ずっと半透明
  - 変更後: D-padボタンを押し続けている間のみ半透明（0.65）
  - 半透明化は0.5秒、不透明化は0.2秒のsmoothstepフェード
  - `useFrame` + progress-based lerpで実装（フレームループ内で`needsUpdate`不使用）
  - `onPointerCancel` 追加でstuck-dim（固まったまま）対策

## Test plan

- [ ] ARモード（モバイル・カメラON）で角度調整ドロアーを開く
- [ ] ドロアーを開いただけでは3Dモデルが不透明のままであること
- [ ] D-padボタンを押し続けている間のみ半透明（0.65）になること
- [ ] ボタンを離すと0.2秒でふわっと不透明に戻ること
- [ ] 上下ボタンで視点ピッチ角度（±30°）が調整されること
- [ ] エリア外でのフローが正しくスキップされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)